### PR TITLE
Add initial health check website

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "boysstateappweb",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "boysstateappweb",
   "version": "1.0.0",
   "description": "> **Disclaimer:**\r >\r > This project is being developed to support Boys State & Girls State programs affiliated with the American Legion, but is **not** created, funded, or officially supported by the American Legion. No endorsement or sponsorship is implied. All branding, configuration, and operational decisions are made independently by the app’s creators and participating programs.",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node src/index.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,29 @@
+const http = require('node:http');
+
+const API_URL = process.env.API_URL || 'http://localhost:3000';
+
+const server = http.createServer(async (req, res) => {
+  if (req.url === '/') {
+    try {
+      const apiRes = await fetch(`${API_URL}/health`);
+      const body = await apiRes.text();
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(`<html><body><h1>API Health</h1><pre>${body}</pre></body></html>`);
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'text/html' });
+      res.end(`<html><body><h1>Error connecting to API</h1><pre>${err.message}</pre></body></html>`);
+    }
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 8080;
+  server.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+module.exports = server;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,39 @@
+const http = require('node:http');
+const { once } = require('node:events');
+const assert = require('node:assert');
+
+const apiServer = http.createServer((req, res) => {
+  if (req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('ok');
+  }
+});
+
+async function startServer(server) {
+  server.listen(0);
+  await once(server, 'listening');
+  return server.address().port;
+}
+
+async function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+const test = require('node:test');
+
+test('GET / returns API health data', async () => {
+  const apiPort = await startServer(apiServer);
+  process.env.API_URL = `http://127.0.0.1:${apiPort}`;
+  process.env.NODE_ENV = 'test';
+  const app = require('../src/index');
+  const appPort = await startServer(app);
+
+  const res = await fetch(`http://127.0.0.1:${appPort}/`);
+  const text = await res.text();
+
+  assert.strictEqual(res.status, 200);
+  assert.ok(text.includes('ok'));
+
+  await stopServer(app);
+  await stopServer(apiServer);
+});


### PR DESCRIPTION
## Summary
- add a minimal HTTP server to call the API health endpoint
- configure start and test scripts
- implement a basic integration test for the health check

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6858ab866c74832da18bf9fa15536067