### PR TITLE
Convert to static HTML site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This repository contains the **web-based admin portal** for Boys State App. The portal enables staff and administrators to manage programs, schedules, users, elections, integrations, logs, and resources securely via the web.
 
-* Modern web stack (React / Angular / \[replace with stack])
+* Simple static HTML pages served by a lightweight Node server for local development
 * Admin login, program and user management
 * Schedule, notifications, and resource editing
 * Branding, integrations, and election management
@@ -40,6 +40,12 @@ This repository contains the **web-based admin portal** for Boys State App. The 
 4. **Connect to backend:**
 
    * Ensure [Backend Services](https://github.com/yourorg/boysstate-backend) API is running and configured.
+
+## Deployment
+
+This site is designed to be hosted on **Netlify**. The `public` directory contains
+the static HTML pages served by Netlify. Simply connect your GitHub repository to
+Netlify and set the publish directory to `public`. No build step is required.
 
 ## Agent Specification
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,13 @@
+# Deployment Guide
+
+This project now uses static HTML files located in the `public` directory. For local development a small Node server (`src/index.js`) serves these files.
+
+## Deploying to Netlify
+
+1. Push the repository to GitHub.
+2. In Netlify, create a new site from GitHub and select this repository.
+3. Set the **publish directory** to `public`.
+4. No build command is required.
+5. Deploy the site.
+
+Netlify will host the HTML pages directly from the `public` folder.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Boys State App Admin Portal</title>
+</head>
+<body>
+  <h1>Boys State App Admin Portal</h1>
+  <p id="status">Loading API status...</p>
+  <script>
+    fetch((window.API_URL || 'http://localhost:3000') + '/health')
+      .then(res => res.text())
+      .then(text => {
+        document.getElementById('status').textContent = text;
+      })
+      .catch(err => {
+        document.getElementById('status').textContent = 'Error: ' + err.message;
+      });
+  </script>
+</body>
+</html>

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2,13 +2,6 @@ const http = require('node:http');
 const { once } = require('node:events');
 const assert = require('node:assert');
 
-const apiServer = http.createServer((req, res) => {
-  if (req.url === '/health') {
-    res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end('ok');
-  }
-});
-
 async function startServer(server) {
   server.listen(0);
   await once(server, 'listening');
@@ -21,9 +14,7 @@ async function stopServer(server) {
 
 const test = require('node:test');
 
-test('GET / returns API health data', async () => {
-  const apiPort = await startServer(apiServer);
-  process.env.API_URL = `http://127.0.0.1:${apiPort}`;
+test('GET / returns index page', async () => {
   process.env.NODE_ENV = 'test';
   const app = require('../src/index');
   const appPort = await startServer(app);
@@ -32,8 +23,7 @@ test('GET / returns API health data', async () => {
   const text = await res.text();
 
   assert.strictEqual(res.status, 200);
-  assert.ok(text.includes('ok'));
+  assert.ok(text.includes('Boys State App Admin Portal'));
 
   await stopServer(app);
-  await stopServer(apiServer);
 });


### PR DESCRIPTION
## Summary
- add a static `public/index.html` page
- change server to serve files from `public`
- update tests for the new behavior
- document Netlify deployment in README and new guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6858b27e2bac832da16e7905c38bf7cc