### PR TITLE
Implement basic registration and customization flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ This repository contains the **web-based admin portal** for Boys State App. The 
 
    * Ensure [Backend Services](https://github.com/yourorg/boysstate-backend) API is running and configured.
 
+## Using the Portal
+
+* Navigate to `index.html` and choose **Register** to create an admin account.
+* After registering or logging in, you will be redirected to the **Customize Program** page to set your program name, color, and logo URL.
+
 ## Deployment
 
 This site is designed to be hosted on **Netlify**. The `public` directory contains

--- a/public/customize.html
+++ b/public/customize.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Customize Program - Boys State App Admin Portal</title>
+</head>
+<body>
+  <h1>Customize Program</h1>
+  <form method="post" action="/customize">
+    <label>Program Name: <input name="programName" required></label><br>
+    <label>Primary Color: <input type="color" name="color" value="#0000ff"></label><br>
+    <label>Logo URL: <input name="imageUrl"></label><br>
+    <button type="submit">Save</button>
+  </form>
+  <p><strong>Disclaimer:</strong> This project is being developed to support Boys State &amp; Girls State programs affiliated with the American Legion, but is <strong>not</strong> created, funded, or officially supported by the American Legion. No endorsement or sponsorship is implied.</p>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,10 @@
 </head>
 <body>
   <h1>Boys State App Admin Portal</h1>
+  <nav>
+    <a href="/login.html">Login</a> |
+    <a href="/register.html">Register</a>
+  </nav>
   <p id="status">Loading API status...</p>
   <script>
     fetch((window.API_URL || 'http://localhost:3000') + '/health')
@@ -18,5 +22,6 @@
         document.getElementById('status').textContent = 'Error: ' + err.message;
       });
   </script>
+  <p><strong>Disclaimer:</strong> This project is being developed to support Boys State &amp; Girls State programs affiliated with the American Legion, but is <strong>not</strong> created, funded, or officially supported by the American Legion. No endorsement or sponsorship is implied.</p>
 </body>
 </html>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login - Boys State App Admin Portal</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form method="post" action="/login">
+    <label>Username: <input name="username" required></label><br>
+    <label>Password: <input type="password" name="password" required></label><br>
+    <button type="submit">Login</button>
+  </form>
+  <p>No account? <a href="/register.html">Register here</a>.</p>
+  <p><strong>Disclaimer:</strong> This project is being developed to support Boys State &amp; Girls State programs affiliated with the American Legion, but is <strong>not</strong> created, funded, or officially supported by the American Legion. No endorsement or sponsorship is implied.</p>
+</body>
+</html>

--- a/public/register.html
+++ b/public/register.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Register - Boys State App Admin Portal</title>
+</head>
+<body>
+  <h1>Register</h1>
+  <form method="post" action="/register">
+    <label>Username: <input name="username" required></label><br>
+    <label>Password: <input type="password" name="password" required></label><br>
+    <button type="submit">Register</button>
+  </form>
+  <p>Already have an account? <a href="/login.html">Login here</a>.</p>
+  <p><strong>Disclaimer:</strong> This project is being developed to support Boys State &amp; Girls State programs affiliated with the American Legion, but is <strong>not</strong> created, funded, or officially supported by the American Legion. No endorsement or sponsorship is implied.</p>
+</body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -4,40 +4,112 @@ const path = require('node:path');
 
 const publicDir = path.join(__dirname, '..', 'public');
 
-const server = http.createServer(async (req, res) => {
-  let filePath = req.url === '/' ? 'index.html' : req.url.slice(1);
-  filePath = path.normalize(path.join(publicDir, filePath));
+function parseBody(req) {
+  return new Promise((resolve) => {
+    let data = '';
+    req.on('data', chunk => {
+      data += chunk;
+    });
+    req.on('end', () => {
+      resolve(Object.fromEntries(new URLSearchParams(data)));
+    });
+  });
+}
 
-  // prevent directory traversal attacks
-  if (!filePath.startsWith(publicDir)) {
-    res.writeHead(400);
-    return res.end('Bad Request');
-  }
+function parseCookies(cookieHeader) {
+  if (!cookieHeader) return {};
+  return Object.fromEntries(cookieHeader.split(';').map(c => {
+    const [k, v] = c.trim().split('=');
+    return [k, v];
+  }));
+}
 
-  try {
-    const data = await fs.promises.readFile(filePath);
-    const ext = path.extname(filePath);
-    const type = ext === '.html' ? 'text/html' :
-                 ext === '.css' ? 'text/css' :
-                 ext === '.js' ? 'application/javascript' : 'application/octet-stream';
-    res.writeHead(200, { 'Content-Type': type });
-    res.end(data);
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      res.writeHead(404);
-      res.end('Not Found');
-    } else {
-      res.writeHead(500);
-      res.end('Server Error');
+function createServer() {
+  const users = {};
+
+  return http.createServer(async (req, res) => {
+    const cookies = parseCookies(req.headers.cookie);
+
+    if (req.method === 'POST' && req.url === '/register') {
+      const { username, password } = await parseBody(req);
+      if (!username || !password || users[username]) {
+        res.writeHead(400);
+        return res.end('Invalid registration');
+      }
+      users[username] = { password, program: null };
+      res.writeHead(303, {
+        'Location': '/customize.html',
+        'Set-Cookie': `username=${username}; Path=/`
+      });
+      return res.end();
     }
-  }
-});
 
-if (process.env.NODE_ENV !== 'test') {
+    if (req.method === 'POST' && req.url === '/login') {
+      const { username, password } = await parseBody(req);
+      if (!username || !password || !users[username] || users[username].password !== password) {
+        res.writeHead(401);
+        return res.end('Unauthorized');
+      }
+      res.writeHead(303, {
+        'Location': '/customize.html',
+        'Set-Cookie': `username=${username}; Path=/`
+      });
+      return res.end();
+    }
+
+    if (req.method === 'POST' && req.url === '/customize') {
+      const username = cookies.username;
+      if (!username || !users[username]) {
+        res.writeHead(401);
+        return res.end('Unauthorized');
+      }
+      const { programName, color, imageUrl } = await parseBody(req);
+      users[username].program = { programName, color, imageUrl };
+      res.writeHead(200);
+      return res.end('Program updated');
+    }
+
+    if (req.method === 'GET' && req.url === '/customize.html') {
+      const username = cookies.username;
+      if (!username || !users[username]) {
+        res.writeHead(302, { 'Location': '/login.html' });
+        return res.end();
+      }
+    }
+
+    let filePath = req.url === '/' ? 'index.html' : req.url.slice(1);
+    filePath = path.normalize(path.join(publicDir, filePath));
+
+    if (!filePath.startsWith(publicDir)) {
+      res.writeHead(400);
+      return res.end('Bad Request');
+    }
+
+    try {
+      const data = await fs.promises.readFile(filePath);
+      const ext = path.extname(filePath);
+      const type = ext === '.html' ? 'text/html' :
+                   ext === '.css' ? 'text/css' :
+                   ext === '.js' ? 'application/javascript' : 'application/octet-stream';
+      res.writeHead(200, { 'Content-Type': type });
+      res.end(data);
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404);
+        res.end('Not Found');
+      } else {
+        res.writeHead(500);
+        res.end('Server Error');
+      }
+    }
+  });
+}
+
+if (require.main === module) {
   const port = process.env.PORT || 8080;
-  server.listen(port, () => {
+  createServer().listen(port, () => {
     console.log(`Server running on port ${port}`);
   });
 }
 
-module.exports = server;
+module.exports = createServer;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2,10 +2,10 @@ const http = require('node:http');
 const { once } = require('node:events');
 const assert = require('node:assert');
 
-async function startServer(server) {
-  server.listen(0);
-  await once(server, 'listening');
-  return server.address().port;
+async function startServer(app) {
+  app.listen(0);
+  await once(app, 'listening');
+  return app.address().port;
 }
 
 async function stopServer(server) {
@@ -16,7 +16,8 @@ const test = require('node:test');
 
 test('GET / returns index page', async () => {
   process.env.NODE_ENV = 'test';
-  const app = require('../src/index');
+  const createServer = require('../src/index');
+  const app = createServer();
   const appPort = await startServer(app);
 
   const res = await fetch(`http://127.0.0.1:${appPort}/`);
@@ -24,6 +25,37 @@ test('GET / returns index page', async () => {
 
   assert.strictEqual(res.status, 200);
   assert.ok(text.includes('Boys State App Admin Portal'));
+
+  await stopServer(app);
+});
+
+test('register and customize program', async () => {
+  process.env.NODE_ENV = 'test';
+  const createServer = require('../src/index');
+  const app = createServer();
+  const port = await startServer(app);
+
+  let res = await fetch(`http://127.0.0.1:${port}/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'username=test&password=secret',
+    redirect: 'manual'
+  });
+  assert.strictEqual(res.status, 303);
+  const cookie = res.headers.get('set-cookie');
+  assert.ok(cookie.includes('username=test'));
+
+  res = await fetch(`http://127.0.0.1:${port}/customize`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Cookie': cookie
+    },
+    body: 'programName=TestProgram&color=%23ff0000&imageUrl=logo.png'
+  });
+  const text = await res.text();
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(text, 'Program updated');
 
   await stopServer(app);
 });


### PR DESCRIPTION
## Summary
- add basic user registration, login and customization pages
- support cookie-based auth in the server with POST routes
- update README with instructions for using the portal
- expand tests to cover registration and customization flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6858c417adb4832db33e376e6d34ad32