### PR TITLE
Move inline JS to files and add CSP

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -1,0 +1,70 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const apiBase = window.API_URL || 'https://boysstateappservices.up.railway.app';
+
+  const cancelLogin = document.getElementById('cancelLogin');
+  if (cancelLogin) {
+    cancelLogin.addEventListener('click', () => {
+      window.location.href = '/';
+    });
+  }
+
+  const cancelRegister = document.getElementById('cancelRegister');
+  if (cancelRegister) {
+    cancelRegister.addEventListener('click', () => {
+      window.location.href = '/';
+    });
+  }
+
+  const loginForm = document.getElementById('loginForm');
+  if (loginForm) {
+    loginForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('loginEmail').value;
+      const password = document.getElementById('loginPassword').value;
+      const resp = await fetch(`${apiBase}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      const data = await resp.json();
+      const msg = document.getElementById('loginMessage');
+      if (resp.status === 200) {
+        msg.textContent = 'Login successful!';
+        msg.classList.remove('text-red-600');
+        msg.classList.add('text-green-700');
+        setTimeout(() => {
+          window.location.href = '/';
+        }, 1000);
+      } else {
+        msg.textContent = data.error || 'Login failed.';
+        msg.classList.remove('text-green-700');
+        msg.classList.add('text-red-600');
+      }
+    });
+  }
+
+  const registerForm = document.getElementById('registerForm');
+  if (registerForm) {
+    registerForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('regEmail').value;
+      const password = document.getElementById('regPassword').value;
+      const resp = await fetch(`${apiBase}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      const data = await resp.json();
+      const msg = document.getElementById('registerMessage');
+      if (resp.status === 201) {
+        msg.textContent = 'Registration successful! You can now log in.';
+        msg.classList.remove('text-red-600');
+        msg.classList.add('text-green-700');
+      } else {
+        msg.textContent = data.error || 'Registration failed.';
+        msg.classList.remove('text-green-700');
+        msg.classList.add('text-red-600');
+      }
+    });
+  }
+});

--- a/public/console.html
+++ b/public/console.html
@@ -56,21 +56,6 @@
     &copy; 2025 Boys State App Admin Portal. Not affiliated with or endorsed by the American Legion.
   </footer>
   <!-- Tailwind legend-blue/gold custom colors -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            'legend-blue': '#1B3D6D',
-            'legend-gold': '#FFD700'
-          }
-        }
-      }
-    }
-  </script>
-  <script>
-    // Remove 'hidden' from #main-content after login/session logic is added
-    document.getElementById('main-content').classList.remove('hidden');
-  </script>
+  <script src="console.js"></script>
 </body>
 </html>

--- a/public/console.js
+++ b/public/console.js
@@ -1,0 +1,17 @@
+tailwind.config = {
+  theme: {
+    extend: {
+      colors: {
+        'legend-blue': '#1B3D6D',
+        'legend-gold': '#FFD700'
+      }
+    }
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const main = document.getElementById('main-content');
+  if (main) {
+    main.classList.remove('hidden');
+  }
+});

--- a/public/login.html
+++ b/public/login.html
@@ -36,38 +36,12 @@
     <p class="mt-4 text-center text-sm text-gray-600">
       Don’t have an account?
       <a href="register.html" class="text-blue-700 hover:underline font-semibold">Register</a>
-      <button type="button"
-        onclick="window.location.href='/'"
+      <button type="button" id="cancelLogin"
         class="w-full mt-2 bg-gray-100 hover:bg-gray-200 text-blue-900 font-semibold py-2 rounded-lg transition shadow border border-gray-300">
         Cancel
       </button>
     </p>
   </div>
-  <script>
-    document.getElementById('loginForm').addEventListener('submit', async function(e) {
-      e.preventDefault();
-      const email = document.getElementById('loginEmail').value;
-      const password = document.getElementById('loginPassword').value;
-      const resp = await fetch('https://boysstateappservices.up.railway.app/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
-      });
-      const data = await resp.json();
-      const msg = document.getElementById('loginMessage');
-      if (resp.status === 200) {
-        msg.textContent = "Login successful!";
-        msg.classList.remove("text-red-600");
-        msg.classList.add("text-green-700");
-        setTimeout(() => {
-          window.location.href = '/';
-        }, 1000);
-      } else {
-        msg.textContent = data.error || 'Login failed.';
-        msg.classList.remove("text-green-700");
-        msg.classList.add("text-red-600");
-      }
-    });
-  </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/public/register.html
+++ b/public/register.html
@@ -36,35 +36,12 @@
     <p class="mt-4 text-center text-sm text-gray-600">
       Already have an account?
       <a href="login.html" class="text-blue-700 hover:underline font-semibold">Log in</a>
-      <button type="button"
-        onclick="window.location.href='/'"
+      <button type="button" id="cancelRegister"
         class="w-full mt-2 bg-gray-100 hover:bg-gray-200 text-blue-900 font-semibold py-2 rounded-lg transition shadow border border-gray-300">
         Cancel
       </button>
     </p>
   </div>
-  <script>
-    document.getElementById('registerForm').addEventListener('submit', async function(e) {
-      e.preventDefault();
-      const email = document.getElementById('regEmail').value;
-      const password = document.getElementById('regPassword').value;
-      const resp = await fetch('https://boysstateappservices.up.railway.app/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
-      });
-      const data = await resp.json();
-      const msg = document.getElementById('registerMessage');
-      if (resp.status === 201) {
-        msg.textContent = "Registration successful! You can now log in.";
-        msg.classList.remove("text-red-600");
-        msg.classList.add("text-green-700");
-      } else {
-        msg.textContent = data.error || 'Registration failed.';
-        msg.classList.remove("text-green-700");
-        msg.classList.add("text-red-600");
-      }
-    });
-  </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ function createServer() {
   const users = {};
 
   return http.createServer(async (req, res) => {
+    res.setHeader('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self'");
     const cookies = parseCookies(req.headers.cookie);
 
     if (req.method === 'POST' && req.url === '/register') {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -59,3 +59,18 @@ test('register and customize program', async () => {
 
   await stopServer(app);
 });
+
+test('CSP header is set', async () => {
+  process.env.NODE_ENV = 'test';
+  const createServer = require('../src/index');
+  const app = createServer();
+  const port = await startServer(app);
+
+  const res = await fetch(`http://127.0.0.1:${port}/login.html`);
+  assert.strictEqual(
+    res.headers.get('content-security-policy'),
+    "default-src 'self'; script-src 'self'; style-src 'self'"
+  );
+
+  await stopServer(app);
+});


### PR DESCRIPTION
## Summary
- extract form logic from inline `<script>` blocks into `auth.js`
- move console page scripts into `console.js`
- replace inline button handlers with event listeners
- enforce Content Security Policy header
- verify CSP header via new test

## Testing
- `npm test` *(fails: GET / returns index page expected 200 but got 404; other tests pass)*

------
https://chatgpt.com/codex/tasks/task_b_6862733d3418832d9cb2ff034253250b