### PR TITLE
Handle missing backend endpoints gracefully

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -37,12 +37,26 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       const email = document.getElementById('loginEmail').value;
       const password = document.getElementById('loginPassword').value;
-      const resp = await fetch(`${apiBase}/login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
-      });
-      const data = await resp.json();
+      let resp;
+      try {
+        resp = await fetch(`${apiBase}/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        });
+      } catch (err) {
+        console.error('Network error during login', err);
+        document.getElementById('loginMessage').textContent =
+          'Unable to reach server.';
+        return;
+      }
+
+      let data = {};
+      try {
+        data = await resp.json();
+      } catch (err) {
+        console.error('Invalid JSON from login endpoint', err);
+      }
       const msg = document.getElementById('loginMessage');
       if (resp.status === 200 && data.token) {
         jwtToken = data.token;
@@ -69,12 +83,26 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       const email = document.getElementById('regEmail').value;
       const password = document.getElementById('regPassword').value;
-      const resp = await fetch(`${apiBase}/register`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
-      });
-      const data = await resp.json();
+      let resp;
+      try {
+        resp = await fetch(`${apiBase}/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        });
+      } catch (err) {
+        console.error('Network error during registration', err);
+        document.getElementById('registerMessage').textContent =
+          'Unable to reach server.';
+        return;
+      }
+
+      let data = {};
+      try {
+        data = await resp.json();
+      } catch (err) {
+        console.error('Invalid JSON from registration endpoint', err);
+      }
       const msg = document.getElementById('registerMessage');
       if (resp.status === 201) {
         msg.textContent = 'Registration successful! You can now log in.';

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -4,12 +4,32 @@ document.addEventListener('DOMContentLoaded', async () => {
     return;
   }
 
-  const res = await fetch('/api/programs', { headers: { 'Cookie': document.cookie } });
+  let res;
+  try {
+    res = await fetch('/api/programs', {
+      headers: { 'Cookie': document.cookie }
+    });
+  } catch (err) {
+    console.error('Network error while loading programs', err);
+    document.getElementById('main-content').innerHTML =
+      '<p class="text-red-600">Unable to reach server.</p>';
+    return;
+  }
+
   if (res.status !== 200) {
     window.location.href = 'login.html';
     return;
   }
-  const data = await res.json();
+
+  let data;
+  try {
+    data = await res.json();
+  } catch (err) {
+    console.error('Invalid JSON from /api/programs', err);
+    document.getElementById('main-content').innerHTML =
+      '<p class="text-red-600">Unexpected response from server.</p>';
+    return;
+  }
   document.getElementById('main-content').classList.remove('hidden');
   const listEl = document.getElementById('programList');
   if (!data.programs || data.programs.length === 0) {

--- a/public/js/program_create.js
+++ b/public/js/program_create.js
@@ -9,14 +9,22 @@ document.addEventListener('DOMContentLoaded', () => {
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const data = new URLSearchParams(new FormData(form));
-    const resp = await fetch('/create-program', {
-      method: 'POST',
-      headers: {
-        'Cookie': document.cookie,
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      body: data.toString()
-    });
+    let resp;
+    try {
+      resp = await fetch('/create-program', {
+        method: 'POST',
+        headers: {
+          'Cookie': document.cookie,
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: data.toString()
+      });
+    } catch (err) {
+      console.error('Network error creating program', err);
+      msg.textContent = 'Unable to reach server.';
+      msg.className = 'text-red-600';
+      return;
+    }
     if (resp.status === 201) {
       msg.textContent = 'Program created!';
       msg.className = 'text-green-700';


### PR DESCRIPTION
## Summary
- add fetch error handling in dashboard
- guard against malformed JSON in auth page
- show errors in program create page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863cd883c9c832d8c438f2f0114aa12