### PR TITLE
Fix API URL usage and expired token handling

### DIFF
--- a/public/console.html
+++ b/public/console.html
@@ -57,6 +57,8 @@
     &copy; 2025 Boys State App Admin Portal. Not affiliated with or endorsed by the American Legion.
   </footer>
   <!-- Tailwind legend-blue/gold custom colors -->
+  <script src="js/tokenUtils.js"></script>
+  <script src="js/config.js"></script>
   <script src="js/console.js"></script>
 </body>
 </html>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -37,6 +37,8 @@
   <footer class="bg-legend-blue text-white border-t mt-8 py-4 text-center text-xs">
     &copy; 2025 Boys State App Admin Portal. Not affiliated with or endorsed by the American Legion.
   </footer>
+  <script src="js/tokenUtils.js"></script>
+  <script src="js/config.js"></script>
   <script src="js/dashboard.js"></script>
 </body>
 </html>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,9 +1,27 @@
 let jwtToken = null; // Store in memory by default
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
 
-  if (localStorage.getItem('jwtToken')) {
-    window.location.href = 'dashboard.html';
+  const token = localStorage.getItem('jwtToken');
+  if (token) {
+    const apiBaseTemp = typeof window.API_URL === 'string' && window.API_URL.trim() ? window.API_URL : null;
+    if (!window.isTokenExpired || !window.ensureValidToken) {
+      console.warn('token utils not loaded');
+    }
+    const valid = window.isTokenExpired ? !window.isTokenExpired(token) : true;
+    if (!valid && window.ensureValidToken && apiBaseTemp) {
+      const refreshed = await window.ensureValidToken(apiBaseTemp);
+      if (refreshed) {
+        window.location.href = 'dashboard.html';
+        return;
+      }
+    }
+    if (valid) {
+      window.location.href = 'dashboard.html';
+      return;
+    } else {
+      localStorage.removeItem('jwtToken');
+    }
   }
 
   const apiBase = typeof window.API_URL === 'string' && window.API_URL.trim()

--- a/public/js/console.js
+++ b/public/js/console.js
@@ -1,8 +1,17 @@
-document.addEventListener('DOMContentLoaded', () => {console.log("On console.html, jwtToken:", localStorage.getItem('jwtToken'));
-if (!localStorage.getItem('jwtToken')) {
-  window.location.href = 'login.html';
-  return;
-}
+document.addEventListener('DOMContentLoaded', async () => {
+  console.log("On console.html, jwtToken:", localStorage.getItem('jwtToken'));
+  const apiBase = typeof window.API_URL === 'string' && window.API_URL.trim()
+    ? window.API_URL
+    : null;
+  if (!apiBase) {
+    alert('Configuration error: API_URL is not set. Please contact the site administrator.');
+    return;
+  }
+  let token = await window.ensureValidToken(apiBase);
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
 
 document.getElementById('main-content').classList.remove('hidden');
 
@@ -15,8 +24,8 @@ document.getElementById('main-content').classList.remove('hidden');
     });
   }
 
-  // Optionally: Block access if not logged in
-  if (!localStorage.getItem('jwtToken')) {
+  // Optionally: Block access if token missing
+  if (!token) {
     window.location.href = 'login.html';
   }
 });

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,13 +1,26 @@
 document.addEventListener('DOMContentLoaded', async () => {
-  if (!localStorage.getItem('jwtToken')) {
+  const apiBase = typeof window.API_URL === 'string' && window.API_URL.trim()
+    ? window.API_URL
+    : null;
+  if (!apiBase) {
+    alert('Configuration error: API_URL is not set. Please contact the site administrator.');
+    return;
+  }
+  let token = await window.ensureValidToken(apiBase);
+  if (!token) {
     window.location.href = 'login.html';
     return;
   }
 
   let res;
   try {
-    res = await fetch('/api/programs', {
-      headers: { 'Cookie': document.cookie }
+    token = await window.ensureValidToken(apiBase);
+    if (!token) {
+      window.location.href = 'login.html';
+      return;
+    }
+    res = await fetch(`${apiBase}/api/programs`, {
+      headers: { 'Authorization': `Bearer ${token}` }
     });
   } catch (err) {
     console.error('Network error while loading programs', err);

--- a/public/js/program_create.js
+++ b/public/js/program_create.js
@@ -1,5 +1,13 @@
-document.addEventListener('DOMContentLoaded', () => {
-  if (!localStorage.getItem('jwtToken')) {
+document.addEventListener('DOMContentLoaded', async () => {
+  const apiBase = typeof window.API_URL === 'string' && window.API_URL.trim()
+    ? window.API_URL
+    : null;
+  if (!apiBase) {
+    alert('Configuration error: API_URL is not set. Please contact the site administrator.');
+    return;
+  }
+  let token = await window.ensureValidToken(apiBase);
+  if (!token) {
     window.location.href = 'login.html';
     return;
   }
@@ -11,10 +19,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const data = new URLSearchParams(new FormData(form));
     let resp;
     try {
-      resp = await fetch('/create-program', {
+      token = await window.ensureValidToken(apiBase);
+      if (!token) {
+        window.location.href = 'login.html';
+        return;
+      }
+      resp = await fetch(`${apiBase}/create-program`, {
         method: 'POST',
         headers: {
-          'Cookie': document.cookie,
+          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/x-www-form-urlencoded'
         },
         body: data.toString()

--- a/public/js/tokenUtils.js
+++ b/public/js/tokenUtils.js
@@ -1,0 +1,43 @@
+(() => {
+  function parseJwt(token) {
+    try {
+      return JSON.parse(atob(token.split('.')[1]));
+    } catch {
+      return {};
+    }
+  }
+
+  window.isTokenExpired = function(token) {
+    if (!token) return true;
+    const payload = parseJwt(token);
+    if (!payload.exp) return false;
+    return Date.now() >= payload.exp * 1000;
+  };
+
+  window.ensureValidToken = async function(apiBase) {
+    let token = localStorage.getItem('jwtToken');
+    if (!token) return null;
+    if (!window.isTokenExpired(token)) {
+      return token;
+    }
+    try {
+      const res = await fetch(`${apiBase}/refresh`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.token) {
+          localStorage.setItem('jwtToken', data.token);
+          return data.token;
+        }
+      }
+    } catch (err) {
+      console.error('Token refresh failed', err);
+    }
+    localStorage.removeItem('jwtToken');
+    return null;
+  };
+})();

--- a/public/login.html
+++ b/public/login.html
@@ -42,6 +42,7 @@
       </button>
     </p>
   </div>
+  <script src="js/tokenUtils.js"></script>
   <script src="js/config.js"></script>
   <script src="js/auth.js"></script>
 </body>

--- a/public/program_create.html
+++ b/public/program_create.html
@@ -26,6 +26,8 @@
     </form>
     <p id="createMsg" class="mt-4 text-center"></p>
   </div>
+  <script src="js/tokenUtils.js"></script>
+  <script src="js/config.js"></script>
   <script src="js/program_create.js"></script>
 </body>
 </html>

--- a/public/register.html
+++ b/public/register.html
@@ -42,6 +42,7 @@
       </button>
     </p>
   </div>
+  <script src="js/tokenUtils.js"></script>
   <script src="js/config.js"></script>
   <script src="js/auth.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- ensure all JS fetch calls use `window.API_URL`
- add global token utilities for expiration checking and refresh
- redirect to login when token expired and refresh fails
- include token utils and config on all pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68649ea57844832d927bb3b9c02135c8