### PR TITLE
Add login and security regression tests

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -81,3 +81,91 @@ test('CSP header is set', async () => {
 
   await stopServer(app);
 });
+
+test('login redirects based on program enrollment', async () => {
+  process.env.NODE_ENV = 'test';
+  const createServer = require('../src/index');
+  const app = createServer();
+  const port = await startServer(app);
+
+  // Register user
+  let res = await fetch(`http://127.0.0.1:${port}/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'username=loginuser&password=secret',
+    redirect: 'manual'
+  });
+  assert.strictEqual(res.status, 303);
+
+  // Login with no programs should go to onboarding
+  res = await fetch(`http://127.0.0.1:${port}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'username=loginuser&password=secret',
+    redirect: 'manual'
+  });
+  const loginCookie = res.headers.get('set-cookie');
+  assert.strictEqual(res.status, 303);
+  assert.strictEqual(res.headers.get('location'), '/onboarding.html');
+  assert.ok(loginCookie.includes('username=loginuser'));
+
+  // Create a program for the user
+  await fetch(`http://127.0.0.1:${port}/create-program`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Cookie': loginCookie
+    },
+    body: 'programName=Prog&color=%2300ff00&imageUrl=logo.png'
+  });
+
+  // Login again should redirect to dashboard
+  res = await fetch(`http://127.0.0.1:${port}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'username=loginuser&password=secret',
+    redirect: 'manual'
+  });
+  assert.strictEqual(res.status, 303);
+  assert.strictEqual(res.headers.get('location'), '/dashboard.html');
+
+  await stopServer(app);
+});
+
+test('unauthorized access is blocked', async () => {
+  process.env.NODE_ENV = 'test';
+  const createServer = require('../src/index');
+  const app = createServer();
+  const port = await startServer(app);
+
+  let res = await fetch(`http://127.0.0.1:${port}/create-program`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'programName=Nope&color=%23ff0000&imageUrl=img.png'
+  });
+  assert.strictEqual(res.status, 401);
+
+  res = await fetch(`http://127.0.0.1:${port}/api/programs`);
+  assert.strictEqual(res.status, 401);
+
+  res = await fetch(`http://127.0.0.1:${port}/create-program.html`, { redirect: 'manual' });
+  assert.strictEqual(res.status, 302);
+  assert.strictEqual(res.headers.get('location'), '/login.html');
+
+  await stopServer(app);
+});
+
+test('CSP header is set on index', async () => {
+  process.env.NODE_ENV = 'test';
+  const createServer = require('../src/index');
+  const app = createServer();
+  const port = await startServer(app);
+
+  const res = await fetch(`http://127.0.0.1:${port}/`);
+  assert.strictEqual(
+    res.headers.get('content-security-policy'),
+    "default-src 'self'; script-src 'self'; style-src 'self'"
+  );
+
+  await stopServer(app);
+});


### PR DESCRIPTION
## Summary
- expand admin portal regression test coverage
- add integration tests for login flows
- verify CSP headers on multiple pages
- enforce unauthorized access checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6865151dc8c4832d897eb6365ee0e980