### PR TITLE
Add environment template and clarify config instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment configuration
+# Rename this file to .env and edit the values as needed.
+
+# Port for the local Node server
+PORT=8080
+
+# Base URL of the backend API used by the portal
+API_URL=https://boysstateappservices.up.railway.app

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,10 @@ Thank you for your interest in contributing to the Boys State App web admin port
 3. **Set up prerequisites:**
 
    * Ensure Node.js version is correct and web tooling is up to date.
-4. **Set up environment variables:**
+4. **Configure environment variables and API endpoint:**
 
-   * Copy `.env.example` to `.env` and configure API endpoints, OAuth, and settings.
+   * Copy `.env.example` to `.env` and adjust values such as `PORT` for local testing.
+   * Edit `public/js/config.js` and set `API_URL` to your backend API.
 5. **Run the admin portal:**
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ This repository contains the **web-based admin portal** for Boys State App. The 
    npm install
    # or yarn
    ```
-2. **Set up environment variables:**
+2. **Configure environment variables and API endpoint:**
 
-   * Copy `.env.example` to `.env` and configure API endpoints, OAuth credentials, and program info.
+   * Copy `.env.example` to `.env` and adjust values such as `PORT` for the local server.
+   * Edit `public/js/config.js` and set `API_URL` to your backend API's base URL.
 3. **Run the app:**
 
    ```bash


### PR DESCRIPTION
## Summary
- create `.env.example` showing PORT and API_URL
- update README setup section to mention `.env` and `public/js/config.js`
- update CONTRIBUTING docs with same instructions

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68651521a9f4832d9ed78b152c7543c0