### PR TITLE
Implement global logging and error capture

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -30,4 +30,38 @@ function getLogs() {
   return logs;
 }
 
+function interceptConsole() {
+  const format = (a) => {
+    if (typeof a === 'string') return a;
+    try {
+      return JSON.stringify(a);
+    } catch {
+      return String(a);
+    }
+  };
+  const wrap = (orig, level) => {
+    return (...args) => {
+      orig(...args);
+      const msg = args.map(format).join(' ');
+      log(msg, { level, source: 'console' });
+    };
+  };
+  console.log = wrap(console.log.bind(console), 'info');
+  console.warn = wrap(console.warn.bind(console), 'warn');
+  console.error = wrap(console.error.bind(console), 'error');
+}
+
+function interceptProcessErrors() {
+  process.on('uncaughtException', (err) => {
+    log('Uncaught exception', { level: 'error', error: err.stack || err.message, source: 'process' });
+  });
+  process.on('unhandledRejection', (reason) => {
+    const error = reason instanceof Error ? reason.stack : JSON.stringify(reason);
+    log('Unhandled rejection', { level: 'error', error, source: 'process' });
+  });
+}
+
+interceptConsole();
+interceptProcessErrors();
+
 module.exports = { log, getLogs };


### PR DESCRIPTION
## Summary
- forward console output and unhandled errors to the existing logging API
- audit registration, login, and program creation events
- record server file read failures
- add tests covering new logging behaviours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6866752e6f4c832d93d06fcb25363595