### PR TITLE
Read API_URL from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This repository contains the **web-based admin portal** for Boys State App. The 
 
    * Copy `.env.example` to `.env` and adjust values such as `PORT` for the local server.
    * Edit `public/js/config.js` and set `API_URL` to your backend API's base URL.
-   * The server reads `API_URL` and optional `PROGRAM_ID` to send log events to
-     your backend's `/logs` endpoint.
+   * The server uses `API_URL` (read from the environment or `public/js/config.js`) and optional `PROGRAM_ID`
+     to send log events to your backend's `/logs` endpoint.
 3. **Run the app:**
 
    ```bash


### PR DESCRIPTION
## Summary
- load API_URL from public/js/config.js when env var isn't set
- document how the server finds API_URL
- test fallback to config.js

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6866782a292c832dba9723b5cb334fe6