### PR TITLE
Add log viewer page with API filtering

### DIFF
--- a/public/js/logs.js
+++ b/public/js/logs.js
@@ -1,0 +1,67 @@
+(async function(){
+  const apiBase = window.API_URL;
+  let token = await window.ensureValidToken(apiBase);
+  if(!token){
+    window.location.href = 'login.html';
+    return;
+  }
+
+  const tbody = document.querySelector('#logTable tbody');
+  const pager = document.getElementById('pager');
+
+  async function fetchLogs(page=1){
+    const params = new URLSearchParams();
+    const start = document.getElementById('start').value;
+    const end = document.getElementById('end').value;
+    const search = document.getElementById('search').value;
+    const source = document.getElementById('source').value;
+    const levelSel = Array.from(document.getElementById('level').selectedOptions).map(o=>o.value);
+    if(start) params.set('start', new Date(start).toISOString());
+    if(end) params.set('end', new Date(end).toISOString());
+    if(search) params.set('search', search);
+    if(source) params.set('source', source);
+    levelSel.forEach(l=>params.append('level', l));
+    params.set('page', page);
+    const res = await fetch(`${apiBase}/api/logs?${params.toString()}`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    const data = await res.json();
+    render(data.items);
+    renderPager(page, data.total);
+  }
+
+  function render(items){
+    tbody.innerHTML = '';
+    items.forEach(i=>{
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td class="px-2 py-1 whitespace-nowrap">${i.timestamp}</td>`+
+                     `<td class="px-2 py-1">${i.level}</td>`+
+                     `<td class="px-2 py-1">${i.source}</td>`+
+                     `<td class="px-2 py-1 truncate max-w-xs">${i.message}</td>`;
+      tr.addEventListener('click', ()=>alert(i.message + (i.error ? '\n'+i.error : '')));
+      tbody.appendChild(tr);
+    });
+  }
+
+  function renderPager(page,total){
+    const pageSize = 50;
+    const pages = Math.ceil(total/pageSize) || 1;
+    pager.innerHTML = '';
+    const prev = document.createElement('button');
+    prev.textContent = '<';
+    prev.disabled = page<=1;
+    prev.addEventListener('click',()=>fetchLogs(page-1));
+    pager.appendChild(prev);
+    const span = document.createElement('span');
+    span.textContent = `${page} / ${pages}`;
+    pager.appendChild(span);
+    const next = document.createElement('button');
+    next.textContent = '>';
+    next.disabled = page>=pages;
+    next.addEventListener('click',()=>fetchLogs(page+1));
+    pager.appendChild(next);
+  }
+
+  document.getElementById('apply').addEventListener('click',()=>fetchLogs());
+  fetchLogs();
+})();

--- a/public/logs.html
+++ b/public/logs.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Logs - Boys State App</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="tailwind.css" rel="stylesheet" />
+</head>
+<body class="min-h-screen bg-gray-50 p-4">
+  <h1 class="text-2xl font-bold mb-4">Logs</h1>
+  <div class="mb-4 flex flex-wrap gap-2" id="filters">
+    <input type="date" id="start" class="border rounded p-1" />
+    <input type="date" id="end" class="border rounded p-1" />
+    <select id="level" multiple class="border rounded p-1">
+      <option value="debug">debug</option>
+      <option value="info">info</option>
+      <option value="warn">warn</option>
+      <option value="error">error</option>
+    </select>
+    <select id="source" class="border rounded p-1">
+      <option value="all">all</option>
+      <option value="server">server</option>
+      <option value="auth">auth</option>
+      <option value="program">program</option>
+      <option value="console">console</option>
+      <option value="process">process</option>
+    </select>
+    <input type="text" id="search" placeholder="search" class="border rounded p-1" />
+    <button id="apply" class="bg-blue-600 text-white px-3 py-1 rounded">Apply</button>
+  </div>
+  <table class="min-w-full bg-white" id="logTable">
+    <thead>
+      <tr>
+        <th class="px-2 py-1">Timestamp</th>
+        <th class="px-2 py-1">Level</th>
+        <th class="px-2 py-1">Source</th>
+        <th class="px-2 py-1">Message</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <div id="pager" class="mt-4 flex items-center gap-2"></div>
+  <script src="js/config.js"></script>
+  <script src="js/tokenUtils.js"></script>
+  <script src="js/logs.js"></script>
+</body>
+</html>

--- a/src/logger.js
+++ b/src/logger.js
@@ -13,15 +13,18 @@ function sendToApi(data) {
 }
 
 function log(message, { level = 'info', error = null, source = 'server' } = {}) {
-  const entry = `[${new Date().toISOString()}] ${message}`;
-  logs.push(entry);
-
-  const payload = {
-    programId: process.env.PROGRAM_ID || 'unknown',
+  const entry = {
+    timestamp: new Date().toISOString(),
     level,
     message,
     error,
     source
+  };
+  logs.push(entry);
+
+  const payload = {
+    programId: process.env.PROGRAM_ID || 'unknown',
+    ...entry
   };
   sendToApi(payload);
 }


### PR DESCRIPTION
## Summary
- expand logger to keep structured log objects
- add `/api/logs` endpoint with basic filtering and pagination
- create new `logs.html` and JS for log browsing
- test updated log format and new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6866f9729bac832d87cf66bf0d06adc1