### PR TITLE
Ensure auth token used in logs API calls

### DIFF
--- a/public/js/logs.js
+++ b/public/js/logs.js
@@ -21,6 +21,11 @@ const apiBase =
   
 
 async function fetchLogs(params = {}) {
+  const token = window.ensureValidToken ? await window.ensureValidToken(apiBase) : localStorage.getItem('jwtToken');
+  if (!token) {
+    if (window.location) window.location.href = 'login.html';
+    return;
+  }
   // Always require programId (e.g., "unknown" is valid)
   if (!params.programId) {
     alert('Program ID is required.');
@@ -36,7 +41,7 @@ async function fetchLogs(params = {}) {
     delete params.start;
   }
   if (params.end) {
-    params.dateTo = params.end + 'T23:59:59Z';d
+    params.dateTo = params.end + 'T23:59:59Z';
     delete params.end;
   }
   // Remove only undefined/null fields (leave empty string and "unknown")
@@ -63,7 +68,7 @@ async function fetchLogs(params = {}) {
       params,
       url,
       headers: {
-        'Authorization': `Bearer ${localStorage.getItem('token') || ''}`
+        'Authorization': `Bearer ${token}`
       }
     });
   }
@@ -74,7 +79,7 @@ async function fetchLogs(params = {}) {
   try {
     const response = await fetch(url, {
       headers: {
-        'Authorization': `Bearer ${localStorage.getItem('token') || ''}`
+        'Authorization': `Bearer ${token}`
       }
     });
 
@@ -162,5 +167,5 @@ document.getElementById('filters').addEventListener('submit', e => {
 
 // On first load, show first page of logs
 document.addEventListener('DOMContentLoaded', () => {
-  fetchLogs();
+  fetchLogs(getFilters());
 });

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+test('fetchLogs includes auth header', async () => {
+  const code = fs.readFileSync(path.join(__dirname, '../public/js/logs.js'), 'utf8');
+  const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: () => ({ logs: [], total:0, page:1, pageSize:50 }) });
+  const ensureMock = jest.fn().mockResolvedValue('abc.def');
+  const ctx = {
+    window: { API_URL: 'http://api.test', ensureValidToken: ensureMock, logToServer: jest.fn() },
+    document: {
+      getElementById: jest.fn(id => {
+        if (id === 'apply' || id === 'filters') return { addEventListener: jest.fn() };
+        return { value: 'test' };
+      }),
+      querySelector: jest.fn(() => ({ innerHTML: '', appendChild: jest.fn() })),
+      addEventListener: jest.fn((ev, cb) => { if (ev === 'DOMContentLoaded') cb(); })
+    },
+    fetch: fetchMock,
+    console: { log: () => {} },
+    URLSearchParams,
+    alert: jest.fn()
+  };
+  vm.createContext(ctx);
+  vm.runInContext(code, ctx);
+  await ctx.fetchLogs({ programId: 'test' });
+  expect(ensureMock).toHaveBeenCalled();
+  const opts = fetchMock.mock.calls[0][1];
+  expect(opts.headers.Authorization).toBe('Bearer abc.def');
+});


### PR DESCRIPTION
## Summary
- fix date filter bug in `logs.js`
- ensure `jwtToken` is used when fetching logs
- refresh token with `ensureValidToken` and redirect to login if missing
- load initial logs with current filters
- add regression test covering auth header usage in `fetchLogs`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6867cff2e5ac832d878d0c891b988a9b