### PR TITLE
Limit logs view to user programs

### DIFF
--- a/public/logs.html
+++ b/public/logs.html
@@ -47,8 +47,7 @@
         <div>
           <label for="programId" class="block text-xs font-semibold text-legend-blue mb-1 uppercase tracking-wide">Program</label>
           <select id="programId" class="border border-gray-300 rounded px-2 py-1 focus:border-legend-blue">
-            <option value="unknown">Unknown</option>
-            <option value="system">System</option>
+            <option value="" disabled selected>Loading...</option>
           </select>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- populate Program dropdown dynamically based on logged in user
- update logs page default dropdown
- test program fetch logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686a616225c0832da4caa4be3ca794e2