### PR TITLE
Fix auth token storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This repository contains the **web-based admin portal** for Boys State App. The 
 
 * Navigate to `index.html` and choose **Register** to create an admin account.
 * After registering you will be taken to **onboarding.html**. From there create your first program. Subsequent logins redirect to **dashboard.html** which lists all your programs and shows features based on your role.
-* Authentication tokens are stored in secure, HTTP-only cookies. Ensure your backend sets cookies with `HttpOnly` and `Secure` flags and that all requests use `credentials: "include"`.
+* Authentication tokens are returned by the API and stored in `localStorage`. Subsequent requests include the token via an `Authorization: Bearer` header.
 
 ## Deployment
 

--- a/public/console.html
+++ b/public/console.html
@@ -64,6 +64,7 @@
   <!-- Tailwind legend-blue/gold custom colors -->
   <script src="js/config.js"></script>
   <script src="js/clientLogger.js"></script>
+  <script src="js/authHelper.js"></script>
   <script src="js/console.js"></script>
 </body>
 </html>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -39,6 +39,7 @@
   </footer>
   <script src="js/config.js"></script>
   <script src="js/clientLogger.js"></script>
+  <script src="js/authHelper.js"></script>
   <script src="js/dashboard.js"></script>
 </body>
 </html>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', async () => {
-
+  if (typeof clearAuthToken === "function") clearAuthToken();
   const apiBase = typeof window.API_URL === 'string' && window.API_URL.trim()
     ? window.API_URL
     : null;
@@ -60,10 +60,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
       const msg = document.getElementById('loginMessage');
       if (resp.ok) {
-        if (window.logToServer) {
-          window.logToServer('Login successful', { level: 'info' });
-        }
-        msg.textContent = 'Login successful!';
+          if (window.logToServer) {
+            window.logToServer("Login successful", { level: "info" });
+          }
+          (typeof storeAuthToken === 'function' ? storeAuthToken(data.token) : null);
+          msg.textContent = "Login successful!";
         msg.classList.remove('text-red-600');
         msg.classList.add('text-green-700');
         setTimeout(() => {

--- a/public/js/authHelper.js
+++ b/public/js/authHelper.js
@@ -1,0 +1,12 @@
+function getAuthHeaders() {
+  const token = localStorage.getItem('authToken');
+  return token ? { 'Authorization': `Bearer ${token}` } : {};
+}
+
+function clearAuthToken() {
+  localStorage.removeItem('authToken');
+}
+
+function storeAuthToken(token) {
+  if (token) localStorage.setItem('authToken', token);
+}

--- a/public/js/clientLogger.js
+++ b/public/js/clientLogger.js
@@ -11,9 +11,9 @@
     };
     fetch(`${apiBase}/logs`, {
       method: 'POST',
-      headers: {
+      headers: Object.assign({
         'Content-Type': 'application/json'
-      },
+      }, (typeof getAuthHeaders === 'function' ? getAuthHeaders() : {})),
       credentials: 'include',
       body: JSON.stringify(payload)
     }).catch(() => {});

--- a/public/js/console.js
+++ b/public/js/console.js
@@ -11,7 +11,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
   try {
     const res = await fetch(`${apiBase}/programs`, {
-      credentials: 'include'
+      credentials: 'include',
+      headers: typeof getAuthHeaders === 'function' ? getAuthHeaders() : {},
     });
     if (res.ok) {
       const programs = await res.json().catch(() => null);
@@ -20,6 +21,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.logToServer('Loaded programs', { level: 'info' });
       }
     } else if (res.status === 401) {
+      if (typeof clearAuthToken === 'function') clearAuthToken();
       window.location.href = 'login.html';
       return;
     }
@@ -35,6 +37,7 @@ document.getElementById('main-content').classList.remove('hidden');
   const logoutBtn = document.getElementById('logoutBtn');
   if (logoutBtn) {
     logoutBtn.addEventListener('click', () => {
+      if (typeof clearAuthToken === 'function') clearAuthToken();
       window.location.href = 'login.html'; // Redirect to login or home
     });
   }

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -12,7 +12,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   let res;
   try {
     res = await fetch(`${apiBase}/programs`, {
-      credentials: 'include'
+      credentials: 'include',
+      headers: typeof getAuthHeaders === 'function' ? getAuthHeaders() : {},
     });
   } catch (err) {
     console.error('Network error while loading programs', err);
@@ -25,6 +26,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   if (res.status !== 200) {
+  if (typeof clearAuthToken === "function") clearAuthToken();
+    if (typeof clearAuthToken === 'function') clearAuthToken();
     window.location.href = 'login.html';
     return;
   }
@@ -68,6 +71,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   document.getElementById('logoutBtn').addEventListener('click', () => {
+    if (typeof clearAuthToken === 'function') clearAuthToken();
     window.location.href = 'login.html';
   });
 });

--- a/public/js/logs.js
+++ b/public/js/logs.js
@@ -7,7 +7,8 @@ const apiBase =
 async function loadPrograms() {
   try {
     const res = await fetch(`${apiBase}/programs`, {
-      credentials: 'include'
+      credentials: 'include',
+      headers: typeof getAuthHeaders === "function" ? getAuthHeaders() : {},
     });
     if (!res.ok) return [];
     const data = (await res.json().catch(() => null)) || {};
@@ -114,9 +115,15 @@ async function fetchLogs(params = {}) {
 
   try {
     const response = await fetch(url, {
-      credentials: 'include'
+      credentials: 'include',
+      headers: typeof getAuthHeaders === "function" ? getAuthHeaders() : {},
     });
 
+    if (response.status === 401) {
+      if (typeof clearAuthToken === "function") clearAuthToken();
+      window.location.href = "login.html";
+      return;
+    }
     if (window.logToServer) {
       window.logToServer('Logs API response', {
         level: 'info',
@@ -249,6 +256,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const logoutBtn = document.getElementById('logoutBtn');
   if (logoutBtn && typeof logoutBtn.addEventListener === 'function') {
     logoutBtn.addEventListener('click', () => {
+      if (typeof clearAuthToken === 'function') clearAuthToken();
       if (window.location) window.location.href = 'login.html';
     });
   }

--- a/public/js/programs-create.js
+++ b/public/js/programs-create.js
@@ -22,9 +22,9 @@ document.getElementById('createProgramForm').onsubmit = async function(e) {
     try {
       const res = await fetch(`${apiBaseUrl}/programs`, {
         method: 'POST',
-        headers: {
+        headers: Object.assign({
           'Content-Type': 'application/json'
-        },
+        }, (typeof getAuthHeaders === 'function' ? getAuthHeaders() : {})),
         credentials: 'include',
         body: JSON.stringify({
           name,
@@ -57,4 +57,3 @@ document.getElementById('createProgramForm').onsubmit = async function(e) {
     el.innerHTML = msg;
     el.classList.remove('hidden');
   }
-  

--- a/public/login.html
+++ b/public/login.html
@@ -41,6 +41,7 @@
   </div>
   <script src="js/config.js"></script>
   <script src="js/clientLogger.js"></script>
+  <script src="js/authHelper.js"></script>
   <script src="js/auth.js"></script>
 </body>
 </html>

--- a/public/logs.html
+++ b/public/logs.html
@@ -109,6 +109,8 @@
   </footer>
 
   <script src="js/config.js"></script>
+  <script src="js/authHelper.js"></script>
+  <script src="js/clientLogger.js"></script>
   <script src="js/logs.js"></script>
 </body>
 </html>

--- a/public/programs-create.html
+++ b/public/programs-create.html
@@ -77,6 +77,8 @@
   </footer>
   
   <script src="js/config.js"></script>
+  <script src="js/authHelper.js"></script>
+  <script src="js/clientLogger.js"></script>
   <script src="js/programs-create.js"></script>
   
 </body>

--- a/public/register.html
+++ b/public/register.html
@@ -41,6 +41,7 @@
   </div>
   <script src="js/config.js"></script>
   <script src="js/clientLogger.js"></script>
+  <script src="js/authHelper.js"></script>
   <script src="js/auth.js"></script>
 </body>
 </html>

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -25,6 +25,6 @@ test('console page loads programs with credentials', async () => {
   vm.createContext(ctx);
   vm.runInContext(code, ctx);
   await ready();
-  expect(fetchMock).toHaveBeenCalledWith('http://api.test/programs', { credentials: 'include' });
+  expect(fetchMock).toHaveBeenCalledWith('http://api.test/programs', expect.objectContaining({ credentials: 'include' }));
   expect(logoutBtn.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
 });

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -33,6 +33,6 @@ test('dashboard fetches user programs', async () => {
   vm.createContext(ctx);
   vm.runInContext(code, ctx);
   await ready();
-  expect(fetchMock).toHaveBeenCalledWith('http://api.test/programs', { credentials: 'include' });
+  expect(fetchMock).toHaveBeenCalledWith('http://api.test/programs', expect.objectContaining({ credentials: 'include' }));
   expect(logoutBtn.addEventListener).toHaveBeenCalled();
 });

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -55,7 +55,7 @@ test('loadPrograms fetches user programs', async () => {
   vm.runInContext(code, ctx);
   await ctx.loadPrograms();
   expect(fetchMock).toHaveBeenCalledWith(
-    'http://api.test/programs',
-    { credentials: 'include' }
+    "http://api.test/programs",
+    expect.objectContaining({ credentials: "include" })
   );
 });


### PR DESCRIPTION
## Summary
- store API auth token in `localStorage`
- send token using `Authorization` header from new helper
- clean auth token on logout or unauthorized responses
- update docs and tests for new token handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686a79c33844832d82610320677c81ed