### PR TITLE
Fix timezone dependent test

### DIFF
--- a/test/logs-utils.test.js
+++ b/test/logs-utils.test.js
@@ -21,6 +21,10 @@ test('toISODateString converts local date to ISO', () => {
   };
   vm.createContext(ctx);
   vm.runInContext(code, ctx);
-  expect(ctx.toISODateString('2023-01-01')).toMatch(/^2023-01-01T06:00:00.000Z/);
-  expect(ctx.toISODateString('2023-01-01', true)).toMatch(/^2023-01-02T05:59:59.000Z/);
+
+  const expectedStart = new Date('2023-01-01T00:00:00').toISOString();
+  const expectedEnd = new Date('2023-01-01T23:59:59').toISOString();
+
+  expect(ctx.toISODateString('2023-01-01')).toBe(expectedStart);
+  expect(ctx.toISODateString('2023-01-01', true)).toBe(expectedEnd);
 });


### PR DESCRIPTION
## Summary
- fix `logs-utils.test` to be timezone agnostic
- run Jest test suite with coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686a7ec4ede4832da425f52de61fd9dd