### PR TITLE
Fix Jest coverage for browser scripts

### DIFF
--- a/public/js/logs.js
+++ b/public/js/logs.js
@@ -233,6 +233,10 @@ document.getElementById('apply').addEventListener('click', () => {
   fetchLogs(getFilters());
 });
 
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { loadPrograms, toISODateString, fetchLogs };
+}
+
 // Support Enter key in filter form
 document.getElementById('filters').addEventListener('submit', e => {
   e.preventDefault();

--- a/test/clientLogger.test.js
+++ b/test/clientLogger.test.js
@@ -1,4 +1,3 @@
-const path = require('path');
 
 test('client logger posts console output', () => {
   const fetchMock = jest.fn().mockResolvedValue({});

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -1,9 +1,8 @@
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
+beforeEach(() => {
+  jest.resetModules();
+});
 
 test('console page loads programs with credentials', async () => {
-  const code = fs.readFileSync(path.join(__dirname, '../public/js/console.js'), 'utf8');
   let ready;
   const logoutBtn = { addEventListener: jest.fn() };
   const document = {
@@ -15,15 +14,13 @@ test('console page loads programs with credentials', async () => {
     addEventListener: jest.fn((ev, fn) => { if (ev === 'DOMContentLoaded') ready = fn; })
   };
   const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: () => ({}) });
-  const ctx = {
-    window: { API_URL: 'http://api.test', logToServer: jest.fn(), location: { href: '' } },
-    document,
-    fetch: fetchMock,
-    console: { log: jest.fn(), error: jest.fn() },
-    alert: jest.fn()
-  };
-  vm.createContext(ctx);
-  vm.runInContext(code, ctx);
+  global.window = { API_URL: 'http://api.test', logToServer: jest.fn(), location: { href: '' } };
+  global.document = document;
+  global.fetch = fetchMock;
+  global.console = { log: jest.fn(), error: jest.fn() };
+  global.alert = jest.fn();
+
+  require('../public/js/console.js');
   await ready();
   expect(fetchMock).toHaveBeenCalledWith('http://api.test/programs', expect.objectContaining({ credentials: 'include' }));
   expect(logoutBtn.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -1,9 +1,8 @@
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
+beforeEach(() => {
+  jest.resetModules();
+});
 
 test('dashboard fetches user programs', async () => {
-  const code = fs.readFileSync(path.join(__dirname, '../public/js/dashboard.js'), 'utf8');
   let ready;
   const logoutBtn = { addEventListener: jest.fn() };
   const doc = {
@@ -23,15 +22,13 @@ test('dashboard fetches user programs', async () => {
     status: 200,
     json: () => ({ username: 'u', programs: [{ programName: 'P', role: 'admin' }] })
   });
-  const ctx = {
-    window: { API_URL: 'http://api.test', logToServer: jest.fn() },
-    document: doc,
-    fetch: fetchMock,
-    console: { log: jest.fn(), error: jest.fn() },
-    alert: jest.fn()
-  };
-  vm.createContext(ctx);
-  vm.runInContext(code, ctx);
+  global.window = { API_URL: 'http://api.test', logToServer: jest.fn() };
+  global.document = doc;
+  global.fetch = fetchMock;
+  global.console = { log: jest.fn(), error: jest.fn() };
+  global.alert = jest.fn();
+
+  require('../public/js/dashboard.js');
   await ready();
   expect(fetchMock).toHaveBeenCalledWith('http://api.test/programs', expect.objectContaining({ credentials: 'include' }));
   expect(logoutBtn.addEventListener).toHaveBeenCalled();

--- a/test/logs-utils.test.js
+++ b/test/logs-utils.test.js
@@ -1,30 +1,25 @@
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
+beforeEach(() => {
+  jest.resetModules();
+});
 
 test('toISODateString converts local date to ISO', () => {
-  const code = fs.readFileSync(path.join(__dirname, '../public/js/logs.js'), 'utf8');
   const stubEl = { addEventListener: jest.fn(), classList: { remove: jest.fn(), add: jest.fn() }, innerHTML: '', appendChild: jest.fn() };
-  const ctx = {
-    window: {},
-    document: {
-      addEventListener: jest.fn(),
-      getElementById: jest.fn(() => stubEl),
-      querySelector: jest.fn(() => stubEl),
-      querySelectorAll: jest.fn(() => [])
-    },
-    console: { log: () => {}, error: () => {} },
-    fetch: jest.fn(),
-    alert: jest.fn(),
-    URLSearchParams,
-    setTimeout
+  global.window = {};
+  global.document = {
+    addEventListener: jest.fn(),
+    getElementById: jest.fn(() => stubEl),
+    querySelector: jest.fn(() => stubEl),
+    querySelectorAll: jest.fn(() => [])
   };
-  vm.createContext(ctx);
-  vm.runInContext(code, ctx);
+  global.console = { log: () => {}, error: () => {} };
+  global.fetch = jest.fn();
+  global.alert = jest.fn();
+
+  const mod = require('../public/js/logs.js');
 
   const expectedStart = new Date('2023-01-01T00:00:00').toISOString();
   const expectedEnd = new Date('2023-01-01T23:59:59').toISOString();
 
-  expect(ctx.toISODateString('2023-01-01')).toBe(expectedStart);
-  expect(ctx.toISODateString('2023-01-01', true)).toBe(expectedEnd);
+  expect(mod.toISODateString('2023-01-01')).toBe(expectedStart);
+  expect(mod.toISODateString('2023-01-01', true)).toBe(expectedEnd);
 });

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -1,61 +1,55 @@
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
+beforeEach(() => {
+  jest.resetModules();
+});
 
 test('fetchLogs uses credentials include', async () => {
-  const code = fs.readFileSync(path.join(__dirname, '../public/js/logs.js'), 'utf8');
   const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: () => ({ logs: [], total:0, page:1, pageSize:50 }) });
-  const ctx = {
-    window: { API_URL: 'http://api.test', logToServer: jest.fn() },
-    document: {
-      getElementById: jest.fn(id => {
-        if (id === 'apply' || id === 'filters') return { addEventListener: jest.fn() };
-        return { value: 'test', addEventListener: jest.fn() };
-      }),
-      querySelector: jest.fn(() => ({ innerHTML: '', appendChild: jest.fn() })),
-      addEventListener: jest.fn(),
-      createElement: jest.fn(() => ({}))
-    },
-    fetch: fetchMock,
-    console: { log: () => {} },
-    URLSearchParams,
-    alert: jest.fn()
+  const document = {
+    getElementById: jest.fn(id => {
+      if (id === 'apply' || id === 'filters') return { addEventListener: jest.fn() };
+      return { value: 'test', addEventListener: jest.fn() };
+    }),
+    querySelector: jest.fn(() => ({ innerHTML: '', appendChild: jest.fn() })),
+    addEventListener: jest.fn(),
+    createElement: jest.fn(() => ({}))
   };
-  vm.createContext(ctx);
-  vm.runInContext(code, ctx);
-  await ctx.fetchLogs({ programId: 'test' });
+  global.window = { API_URL: 'http://api.test', logToServer: jest.fn() };
+  global.document = document;
+  global.fetch = fetchMock;
+  global.console = { log: () => {} };
+  global.alert = jest.fn();
+
+  const mod = require('../public/js/logs.js');
+  await mod.fetchLogs({ programId: 'test' });
   const opts = fetchMock.mock.calls[0][1];
   expect(opts.credentials).toBe('include');
 });
 
 test('loadPrograms fetches user programs', async () => {
-  const code = fs.readFileSync(path.join(__dirname, '../public/js/logs.js'), 'utf8');
   const fetchMock = jest.fn().mockResolvedValueOnce({
     ok: true,
     json: () => ({ programs: [{ id: '1', name: 'A' }, { id: '2', name: 'B' }] })
   });
-  const ctx = {
-    window: { API_URL: 'http://api.test', logToServer: jest.fn() },
-    document: {
-      getElementById: jest.fn(id => {
-        if (id === 'apply' || id === 'filters') return { addEventListener: jest.fn() };
-        if (id === 'programId') return { innerHTML: '', appendChild: jest.fn(), addEventListener: jest.fn() };
-        return { value: 'test', addEventListener: jest.fn() };
-      }),
-      querySelector: jest.fn(() => ({ innerHTML: '', appendChild: jest.fn() })),
-      addEventListener: jest.fn(),
-      createElement: jest.fn(() => ({}))
-    },
-    fetch: fetchMock,
-    console: { log: () => {} },
-    URLSearchParams,
-    alert: jest.fn()
+  const document = {
+    getElementById: jest.fn(id => {
+      if (id === 'apply' || id === 'filters') return { addEventListener: jest.fn() };
+      if (id === 'programId') return { innerHTML: '', appendChild: jest.fn(), addEventListener: jest.fn() };
+      return { value: 'test', addEventListener: jest.fn() };
+    }),
+    querySelector: jest.fn(() => ({ innerHTML: '', appendChild: jest.fn() })),
+    addEventListener: jest.fn(),
+    createElement: jest.fn(() => ({}))
   };
-  vm.createContext(ctx);
-  vm.runInContext(code, ctx);
-  await ctx.loadPrograms();
+  global.window = { API_URL: 'http://api.test', logToServer: jest.fn() };
+  global.document = document;
+  global.fetch = fetchMock;
+  global.console = { log: () => {} };
+  global.alert = jest.fn();
+
+  const mod = require('../public/js/logs.js');
+  await mod.loadPrograms();
   expect(fetchMock).toHaveBeenCalledWith(
-    "http://api.test/programs",
-    expect.objectContaining({ credentials: "include" })
+    'http://api.test/programs',
+    expect.objectContaining({ credentials: 'include' })
   );
 });

--- a/test/programs-create.test.js
+++ b/test/programs-create.test.js
@@ -1,9 +1,8 @@
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
+beforeEach(() => {
+  jest.resetModules();
+});
 
 test('program creation posts JSON with credentials', async () => {
-  const code = fs.readFileSync(path.join(__dirname, '../public/js/programs-create.js'), 'utf8');
   const form = {};
   const nameInput = { value: 'Test Program' };
   const yearInput = { value: '2024' };
@@ -22,9 +21,12 @@ test('program creation posts JSON with credentials', async () => {
     })
   };
   const fetchMock = jest.fn().mockResolvedValue({ status: 201, json: () => ({ id: 1, name: 'Test Program', year: 2024 }) });
-  const ctx = { window: { API_URL: 'http://api.test' }, document: doc, fetch: fetchMock, console: { error: jest.fn() } };
-  vm.createContext(ctx);
-  vm.runInContext(code, ctx);
+  global.window = { API_URL: 'http://api.test' };
+  global.document = doc;
+  global.fetch = fetchMock;
+  global.console = { error: jest.fn() };
+
+  require('../public/js/programs-create.js');
   await form.onsubmit({ preventDefault: () => {} });
   expect(fetchMock).toHaveBeenCalledWith('http://api.test/programs', expect.objectContaining({ credentials: 'include' }));
 });


### PR DESCRIPTION
## Summary
- require browser scripts directly in tests instead of using `vm`
- export functions from `public/js/logs.js` for easier testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686a849fe378832dbd019e19a11d13e5