### PR TITLE
Improve test coverage

### DIFF
--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -209,3 +209,31 @@ test('register handles bad response', async () => {
   await handler({ preventDefault: () => {} });
   expect(msgEl.textContent).toBe('nope');
 });
+
+test('cancel buttons navigate home', () => {
+  let ready;
+  let loginHandler;
+  let registerHandler;
+  const cancelLogin = { addEventListener: jest.fn((ev, fn) => { if(ev==='click') loginHandler = fn; }) };
+  const cancelRegister = { addEventListener: jest.fn((ev, fn) => { if(ev==='click') registerHandler = fn; }) };
+  const doc = {
+    getElementById: jest.fn(id => {
+      if (id === 'cancelLogin') return cancelLogin;
+      if (id === 'cancelRegister') return cancelRegister;
+      return null;
+    }),
+    querySelectorAll: jest.fn(() => []),
+    addEventListener: jest.fn((ev, fn) => { if(ev==='DOMContentLoaded') ready = fn; })
+  };
+  global.window = { API_URL: 'http://api.test', location: { href: '' }, logToServer: jest.fn() };
+  global.document = doc;
+  global.fetch = jest.fn();
+  global.alert = jest.fn();
+
+  require('../public/js/auth.js');
+  ready();
+  loginHandler();
+  expect(global.window.location.href).toBe('/');
+  registerHandler();
+  expect(global.window.location.href).toBe('/');
+});

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -104,3 +104,28 @@ test('console redirects on 401', async () => {
   await ready();
   expect(global.window.location.href).toBe('login.html');
 });
+
+test('logout button click navigates to login page', async () => {
+  let ready;
+  let clickHandler;
+  const logoutBtn = { addEventListener: jest.fn((ev, fn) => { if (ev === 'click') clickHandler = fn; }) };
+  const document = {
+    getElementById: jest.fn(id => {
+      if (id === 'logoutBtn') return logoutBtn;
+      if (id === 'main-content') return { classList: { remove: jest.fn() } };
+      return null;
+    }),
+    addEventListener: jest.fn((ev, fn) => { if (ev === 'DOMContentLoaded') ready = fn; })
+  };
+  const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: () => ({}) });
+  global.window = { API_URL: 'http://api.test', logToServer: jest.fn(), location: { href: '' } };
+  global.document = document;
+  global.fetch = fetchMock;
+  global.console = { log: jest.fn(), error: jest.fn() };
+  global.alert = jest.fn();
+
+  require('../public/js/console.js');
+  await ready();
+  clickHandler();
+  expect(global.window.location.href).toBe('login.html');
+});

--- a/test/programs-create.test.js
+++ b/test/programs-create.test.js
@@ -149,3 +149,24 @@ test('program creation handles network error', async () => {
   await form.onsubmit({ preventDefault: () => {} });
   expect(errorEl.innerHTML).toContain('Network');
 });
+
+test('showSuccess and showError modify DOM', () => {
+  const successEl = { classList: { remove: jest.fn() }, innerHTML: '' };
+  const errorEl = { classList: { remove: jest.fn() }, innerHTML: '' };
+  const doc = {
+    getElementById: jest.fn(id => {
+      if (id === 'formSuccess') return successEl;
+      if (id === 'formError') return errorEl;
+      return {};
+    })
+  };
+  const ctx = { window: { API_URL: 'http://api.test' }, document: doc };
+  vm.createContext(ctx);
+  vm.runInContext(code, ctx);
+  ctx.showSuccess('yay');
+  expect(successEl.innerHTML).toBe('yay');
+  expect(successEl.classList.remove).toHaveBeenCalledWith('hidden');
+  ctx.showError('bad');
+  expect(errorEl.innerHTML).toBe('bad');
+  expect(errorEl.classList.remove).toHaveBeenCalledWith('hidden');
+});


### PR DESCRIPTION
## Summary
- extend authentication tests to cover cancel buttons
- add DOM render tests for programs-create
- verify console logout handler triggers navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686a8e3964c8832d8b57239f3ad10e88