### PR TITLE
Fix timezone handling in logs date util

### DIFF
--- a/public/js/logs.js
+++ b/public/js/logs.js
@@ -39,9 +39,9 @@ function toISODateString(dateVal, isEndOfDay = false) {
   if (!dateVal) return undefined;
   // If already has a time, just return as is (assume already UTC)
   if (dateVal.includes('T')) return dateVal;
-  // Otherwise, append time and convert to ISO (treat as UTC)
+  // Otherwise, append time and convert to ISO using local timezone
   const base = isEndOfDay ? 'T23:59:59' : 'T00:00:00';
-  return new Date(dateVal + base + 'Z').toISOString();
+  return new Date(dateVal + base).toISOString();
 }
 
   function getFilters() {


### PR DESCRIPTION
## Summary
- fix `toISODateString` so `YYYY-MM-DD` values are parsed as local time before converting to ISO

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686e60d4ab38832d957335ae0f386339