### PR TITLE
Add tests for application utils and validation

### DIFF
--- a/public/js/apply-utils.js
+++ b/public/js/apply-utils.js
@@ -12,3 +12,7 @@ async function fetchApplicationConfig(programId) {
     return await response.json();
 }
 
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { getProgramId, fetchApplicationConfig };
+}
+

--- a/public/js/apply-validation.js
+++ b/public/js/apply-validation.js
@@ -144,3 +144,7 @@ function addValidationListeners(form, config) {
       });
 }
 
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { validateField, addValidationListeners };
+}
+

--- a/test/apply-utils.test.js
+++ b/test/apply-utils.test.js
@@ -1,0 +1,28 @@
+const { getProgramId, fetchApplicationConfig } = require('../public/js/apply-utils.js');
+
+describe('apply-utils', () => {
+  afterEach(() => {
+    delete global.window;
+    delete global.fetch;
+  });
+
+  test('getProgramId returns value from query string', () => {
+    global.window = { location: { search: '?programId=test123&foo=bar' } };
+    expect(getProgramId()).toBe('test123');
+  });
+
+  test('fetchApplicationConfig returns JSON data', async () => {
+    const data = { a: 1 };
+    global.window = { API_URL: 'http://api.example' };
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => data });
+    const result = await fetchApplicationConfig('prog');
+    expect(fetch).toHaveBeenCalledWith('http://api.example/api/programs/prog/application', { method: 'GET' });
+    expect(result).toEqual(data);
+  });
+
+  test('fetchApplicationConfig throws on failure', async () => {
+    global.window = { API_URL: 'http://api.example' };
+    global.fetch = jest.fn().mockResolvedValue({ ok: false });
+    await expect(fetchApplicationConfig('prog')).rejects.toThrow('Could not load application configuration.');
+  });
+});

--- a/test/apply-validation.test.js
+++ b/test/apply-validation.test.js
@@ -1,0 +1,40 @@
+const { validateField } = require('../public/js/apply-validation.js');
+
+describe('validateField', () => {
+  beforeEach(() => {
+    global.document = { getElementById: jest.fn(() => ({ textContent: '' })) };
+  });
+
+  afterEach(() => {
+    delete global.document;
+  });
+
+  test('flags missing required short answer', () => {
+    const q = { id: 1, type: 'short_answer', required: true };
+    const form = { q_1: { value: '' } };
+    const valid = validateField(q, form);
+    expect(valid).toBe(false);
+    expect(document.getElementById).toHaveBeenCalledWith('err_q_1');
+    expect(document.getElementById.mock.results[0].value.textContent).toBe('This field is required.');
+  });
+
+  test('accepts valid email and clears error', () => {
+    const q = { id: 2, type: 'email', required: true };
+    const errEl = { textContent: 'old' };
+    document.getElementById = jest.fn(() => errEl);
+    const form = { q_2: { value: 'test@example.com' } };
+    const valid = validateField(q, form);
+    expect(valid).toBe(true);
+    expect(errEl.textContent).toBe('');
+  });
+
+  test('rejects invalid email', () => {
+    const q = { id: 3, type: 'email', required: true };
+    const errEl = { textContent: '' };
+    document.getElementById = jest.fn(() => errEl);
+    const form = { q_3: { value: 'invalid' } };
+    const valid = validateField(q, form);
+    expect(valid).toBe(false);
+    expect(errEl.textContent).toBe('Please enter a valid email address.');
+  });
+});


### PR DESCRIPTION
## Summary
- export apply helper functions for Node-based tests
- add tests for application utilities and field validation logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e956e7324832d960ce1f48918e593