### PR TITLE
test: expand coverage

### DIFF
--- a/public/js/branding-contact.js
+++ b/public/js/branding-contact.js
@@ -178,6 +178,6 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { getProgramIdFromUrl, loadConfig, resetForm };
+  module.exports = { getProgramIdFromUrl, loadConfig, resetForm, loadBrandingContactFromApi, saveConfig };
 }
 

--- a/test/apply-submit.test.js
+++ b/test/apply-submit.test.js
@@ -31,5 +31,72 @@ describe('handleFormSubmit', () => {
     expect(formStatus.textContent).toContain('Application submitted');
     expect(form.reset).toHaveBeenCalled();
   });
+
+  test('handles multiple question types and validations', async () => {
+    global.validateField = jest.fn().mockReturnValue(true);
+    const form = {
+      q_short: { value: '' },
+      q_email: { value: 'bad' },
+      q_number: { value: '' },
+      q_phone: { value: 'abc' },
+      q_dropdown: { value: '' },
+      q_date: { value: '' },
+      q_range_start: { value: '' },
+      q_range_end: { value: '' },
+      q_file: { files: [] },
+      q_bool: { checked: false },
+      q_addr_line1: { value: '' },
+      q_addr_city: { value: '' },
+      q_addr_state: { value: '' },
+      q_addr_zip: { value: '' },
+      querySelectorAll: jest.fn().mockReturnValue([]),
+      querySelector: jest.fn().mockReturnValue(null),
+      reset: jest.fn()
+    };
+    const formStatus = { textContent: '', classList: { remove: jest.fn(), add: jest.fn() } };
+    const config = {
+      questions: [
+        { id: 'short', type: 'short_answer', text: 'Short', required: true },
+        { id: 'email', type: 'email', text: 'Email', required: true },
+        { id: 'number', type: 'number', text: 'Number', required: true },
+        { id: 'phone', type: 'phone', text: 'Phone', required: true },
+        { id: 'check', type: 'checkbox', text: 'Check', required: true },
+        { id: 'radio', type: 'radio', text: 'Radio', required: true },
+        { id: 'dropdown', type: 'dropdown', text: 'Dropdown', required: true },
+        { id: 'date', type: 'date', text: 'Date', required: true },
+        { id: 'range', type: 'date_range', text: 'Range', required: true },
+        { id: 'file', type: 'file', text: 'File', required: true },
+        { id: 'bool', type: 'boolean', text: 'Bool', required: true },
+        { id: 'addr', type: 'address', text: 'Addr', required: true }
+      ]
+    };
+    await handleFormSubmit({ preventDefault(){} }, form, config, formStatus);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(formStatus.textContent).toContain('Please');
+
+    // Now test optional fields to cover false branches
+    const optForm = {
+      q_short: { value: 'a' },
+      q_email: { value: 'test@example.com' },
+      q_number: { value: '1' },
+      q_phone: { value: '1234567' },
+      q_dropdown: { value: 'x' },
+      q_date: { value: '2024-01-01' },
+      q_range_start: { value: '2024-01-01' },
+      q_range_end: { value: '2024-01-02' },
+      q_file: { files: [{ name: 'f' }] },
+      q_bool: { checked: true },
+      q_addr_line1: { value: 'l1' },
+      q_addr_city: { value: 'c' },
+      q_addr_state: { value: 's' },
+      q_addr_zip: { value: 'z' },
+      querySelectorAll: jest.fn().mockReturnValue([{ value: 'v', checked: true }]),
+      querySelector: jest.fn().mockReturnValue({ value: 'v' }),
+      reset: jest.fn()
+    };
+    const optConfig = { questions: config.questions.map(q => ({ ...q, required: false })) };
+    await handleFormSubmit({ preventDefault(){} }, optForm, optConfig, formStatus);
+    expect(global.fetch).toHaveBeenCalled();
+  });
 });
 

--- a/test/apply.test.js
+++ b/test/apply.test.js
@@ -1,5 +1,6 @@
 describe('apply.js', () => {
   test('initializes form when programId present', async () => {
+    jest.resetModules();
     let ready;
     const form = { onsubmit: null, innerHTML: '' };
     const formStatus = {};
@@ -20,6 +21,38 @@ describe('apply.js', () => {
     expect(global.renderApplicationForm).toHaveBeenCalled();
     expect(global.addValidationListeners).toHaveBeenCalled();
     expect(typeof form.onsubmit).toBe('function');
+  });
+
+  test('shows message when programId missing', async () => {
+    jest.resetModules();
+    let ready;
+    const form = { innerHTML: '' };
+    global.document = {
+      getElementById: id => (id === 'applicationForm' ? form : { innerHTML: '' }),
+      addEventListener: (ev, fn) => { if (ev === 'DOMContentLoaded') ready = fn; }
+    };
+    global.getProgramId = jest.fn().mockReturnValue('');
+    require('../public/js/apply.js');
+    await ready();
+    expect(form.innerHTML).toContain('No program selected');
+  });
+
+  test('shows error when config fetch fails', async () => {
+    jest.resetModules();
+    let ready;
+    const form = { innerHTML: '' };
+    global.document = {
+      getElementById: id => (id === 'applicationForm' ? form : { innerHTML: '' }),
+      addEventListener: (ev, fn) => { if (ev === 'DOMContentLoaded') ready = fn; }
+    };
+    global.getProgramId = jest.fn().mockReturnValue('abc');
+    global.fetchApplicationConfig = jest.fn().mockRejectedValue(new Error('fail'));
+    global.renderApplicationForm = jest.fn();
+    global.addValidationListeners = jest.fn();
+    global.handleFormSubmit = jest.fn();
+    require('../public/js/apply.js');
+    await ready();
+    expect(form.innerHTML).toContain('Could not load application');
   });
 });
 

--- a/test/programs-config.test.js
+++ b/test/programs-config.test.js
@@ -44,6 +44,17 @@ describe('programs-config.js', () => {
     expect(linkA.href).toBe('a?programId=p2');
   });
 
+  test('renderProgramSelector handles no programs', () => {
+    funcs.renderProgramSelector([], null);
+    expect(global.container.innerHTML).toContain('No programs found');
+  });
+
+  test('updateConfigLinks updates hrefs', () => {
+    funcs.updateConfigLinks('xyz');
+    expect(global.link.href).toBe('page?programId=xyz');
+    expect(global.window.selectedProgramId).toBe('xyz');
+  });
+
   test('fetchProgramsAndRenderSelector fetches and renders', async () => {
     global.localStorage.getItem = jest.fn(() => 'user');
     global.getAuthHeaders = () => ({});
@@ -54,6 +65,26 @@ describe('programs-config.js', () => {
     await funcs.fetchProgramsAndRenderSelector();
     expect(global.fetch).toHaveBeenCalled();
     expect(global.container.innerHTML).toContain('Prog1');
+  });
+
+  test('getUsername falls back to sessionStorage', () => {
+    global.localStorage.getItem = jest.fn(() => null);
+    global.sessionStorage.getItem = jest.fn(() => 'sess');
+    expect(funcs.getUsername()).toBe('sess');
+  });
+
+  test('fetchProgramsAndRenderSelector shows message when no user', async () => {
+    global.localStorage.getItem = jest.fn(() => null);
+    await funcs.fetchProgramsAndRenderSelector();
+    expect(global.container.innerHTML).toContain('No user found');
+  });
+
+  test('fetchProgramsAndRenderSelector handles errors', async () => {
+    global.localStorage.getItem = jest.fn(() => 'user');
+    global.getAuthHeaders = () => ({});
+    global.fetch = jest.fn(() => Promise.reject(new Error('fail')));
+    await funcs.fetchProgramsAndRenderSelector();
+    expect(global.container.innerHTML).toContain('Error loading programs');
   });
 });
 


### PR DESCRIPTION
## Summary
- add exports for branding contact functions to enable testing
- broaden submit handler tests across question types
- add comprehensive DOMContentLoaded and API tests for admin modules

## Testing
- `npm test` *(fails: coverage threshold for branches not met 77.55%)*

------
https://chatgpt.com/codex/tasks/task_b_688eab674d20832db71816753a4b0805