### PR TITLE
feat: improve city state zip interactions

### DIFF
--- a/public/js/apply-address.js
+++ b/public/js/apply-address.js
@@ -37,11 +37,15 @@ function initAddressHelpers(form) {
         if (!res.ok) return;
         const data = await res.json();
         const errDiv = document.getElementById(`err_${base}`);
-        if (data.states && stateSelect.value && !data.states.includes(stateSelect.value)) {
-          errDiv.textContent = 'ZIP code does not match selected state.';
-        } else if (errDiv.textContent === 'ZIP code does not match selected state.') {
-          errDiv.textContent = '';
+        let err = '';
+        const enteredState = stateSelect.value;
+        const enteredCity = cityInput.value.trim().toUpperCase();
+        if (data.states && enteredState && !data.states.includes(enteredState)) {
+          err = 'ZIP code does not match selected state.';
+        } else if (data.cities && enteredCity && !data.cities.includes(enteredCity)) {
+          err = 'ZIP code does not match entered city.';
         }
+        errDiv.textContent = err;
       } catch {}
     });
   });

--- a/test/apply-address.test.js
+++ b/test/apply-address.test.js
@@ -23,7 +23,7 @@ test('city input populates state options and zip validates state', async () => {
 
   global.fetch = jest.fn()
     .mockResolvedValueOnce({ ok: true, json: async () => ({ cities: ['SPRINGFIELD'], states: ['IL', 'MO'] }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ states: ['TX'] }) });
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ states: ['TX'], cities: ['CORPUS CHRISTI'] }) });
 
   initAddressHelpers(form);
 
@@ -61,7 +61,7 @@ test('auto selects state and clears zip error when valid', async () => {
 
   global.fetch = jest.fn()
     .mockResolvedValueOnce({ ok: true, json: async () => ({ cities: ['CORPUS CHRISTI'], states: ['TX'] }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ states: ['TX'] }) });
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ states: ['TX'], cities: ['CORPUS CHRISTI'] }) });
 
   initAddressHelpers(form);
 
@@ -73,6 +73,41 @@ test('auto selects state and clears zip error when valid', async () => {
   zipInput.value = '78401';
   await zipHandler();
   expect(errDiv.textContent).toBe('');
+});
+
+test('flags city mismatch when state matches', async () => {
+  let cityHandler;
+  let zipHandler;
+  const cityInput = { name: 'q_1_city', value: '', addEventListener: (evt, cb) => { if (evt === 'input') cityHandler = cb; } };
+  const stateSelect = { innerHTML: '', value: '' };
+  const zipInput = { name: 'q_1_zip', value: '', addEventListener: (evt, cb) => { if (evt === 'blur') zipHandler = cb; } };
+  const datalist = { innerHTML: '' };
+  const errDiv = { textContent: '' };
+
+  const form = {
+    querySelectorAll: sel => sel === 'input[name$="_city"]' ? [cityInput] : [],
+    querySelector: sel => {
+      if (sel === '[name="q_1_state"]') return stateSelect;
+      if (sel === '[name="q_1_zip"]') return zipInput;
+      return null;
+    }
+  };
+
+  const docMap = { 'q_1_city_list': datalist, 'err_q_1': errDiv };
+  global.document = { getElementById: id => docMap[id] };
+
+  global.fetch = jest.fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ cities: ['SPRINGFIELD'], states: ['IL', 'MO'] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ states: ['TX'], cities: ['CORPUS CHRISTI'] }) });
+
+  initAddressHelpers(form);
+
+  cityInput.value = 'Springfield';
+  await cityHandler();
+  stateSelect.value = 'TX';
+  zipInput.value = '78401';
+  await zipHandler();
+  expect(errDiv.textContent).toBe('ZIP code does not match entered city.');
 });
 
 test('handles short inputs and failed fetches', async () => {

--- a/test/zip-info.test.js
+++ b/test/zip-info.test.js
@@ -24,6 +24,7 @@ test('zip-info endpoint returns matching states', async () => {
   res = await fetch(`http://127.0.0.1:${port}/api/zip-info?zip=78401`);
   data = await res.json();
   expect(data.states).toEqual(['TX']);
+  expect(data.cities).toEqual(['CORPUS CHRISTI']);
 
   await stopServer(app);
 });


### PR DESCRIPTION
## Summary
- expand server zip lookup to track cities and return state options for partial city prefixes
- validate city/state against ZIP on the address form
- test ZIP endpoint and address helper city mismatch cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688f5945c5c0832d93d3cea6d3db9cf2