### PR TITLE
Fix address question submission

### DIFF
--- a/public/js/apply-submit.js
+++ b/public/js/apply-submit.js
@@ -23,7 +23,6 @@ async function handleFormSubmit(e, form, config, formStatus) {
       switch (q.type) {
         case "short_answer":
         case "paragraph":
-        case "address":
         case "section":
         case "static_text":
           value = form[name]?.value?.trim();

--- a/test/apply-submit.test.js
+++ b/test/apply-submit.test.js
@@ -32,6 +32,37 @@ describe('handleFormSubmit', () => {
     expect(form.reset).toHaveBeenCalled();
   });
 
+  test('includes address answers in payload', async () => {
+    global.validateField = jest.fn().mockReturnValue(true);
+    const form = {
+      q_addr_line1: { value: '123 Main St' },
+      q_addr_line2: { value: 'Apt 4' },
+      q_addr_city: { value: 'Springfield' },
+      q_addr_state: { value: 'IL' },
+      q_addr_zip: { value: '62704' },
+      reset: jest.fn()
+    };
+    const formStatus = { textContent: '', classList: { remove: jest.fn(), add: jest.fn() } };
+    const config = { questions: [{ id: 'addr', type: 'address', text: 'Address', required: true }] };
+    await handleFormSubmit({ preventDefault(){} }, form, config, formStatus);
+    expect(global.fetch).toHaveBeenCalled();
+    const [, options] = global.fetch.mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual({
+      answers: [
+        {
+          questionId: 'addr',
+          value: {
+            line1: '123 Main St',
+            line2: 'Apt 4',
+            city: 'Springfield',
+            state: 'IL',
+            zip: '62704'
+          }
+        }
+      ]
+    });
+  });
+
   test('handles multiple question types and validations', async () => {
     global.validateField = jest.fn().mockReturnValue(true);
     const form = {


### PR DESCRIPTION
## Summary
- avoid treating address answers as plain text so full address info is sent
- test that address answers are included in submission payload

## Testing
- `npm test` *(fails: ReferenceError: window is not defined, coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_b_688f6cd59a90832d988d435dad5f1ca6