### PR TITLE
feat: add year and type support for applications

### DIFF
--- a/public/application-config.html
+++ b/public/application-config.html
@@ -44,6 +44,49 @@
     <p class="text-gray-700 mb-6 self-start">
       Create and customize the application form that delegates will use to apply to your program.
     </p>
+
+    <!-- Year and Type Selection -->
+    <div class="flex flex-wrap items-center gap-4 mb-6">
+      <div class="flex items-center gap-2">
+        <label for="year-select" class="font-semibold text-legend-blue">Year:</label>
+        <select id="year-select" class="border rounded px-2 py-1"></select>
+      </div>
+      <div class="flex items-center gap-2">
+        <label for="type-select" class="font-semibold text-legend-blue">Type:</label>
+        <select id="type-select" class="border rounded px-2 py-1">
+          <option value="delegate">Delegate</option>
+          <option value="staff">Staff</option>
+        </select>
+      </div>
+      <button id="create-new-application" class="bg-legend-blue hover:bg-legend-gold text-white font-bold py-2 px-4 rounded-xl shadow transition">
+        Create New Application
+      </button>
+    </div>
+
+    <!-- New Application Form (hidden by default) -->
+    <form id="new-application-form" class="hidden bg-white rounded-2xl shadow-lg p-6 max-w-2xl w-full mx-auto mb-6">
+      <div class="mb-4">
+        <label class="block text-sm font-semibold text-gray-700 mb-1" for="new-app-year">Year</label>
+        <input type="number" id="new-app-year" class="border rounded px-2 py-1 w-full" />
+      </div>
+      <div class="mb-4">
+        <label class="block text-sm font-semibold text-gray-700 mb-1" for="new-app-type">Type</label>
+        <select id="new-app-type" class="border rounded px-2 py-1 w-full">
+          <option value="delegate">Delegate</option>
+          <option value="staff">Staff</option>
+        </select>
+      </div>
+      <div class="mb-4">
+        <label class="block text-sm font-semibold text-gray-700 mb-1" for="copy-from-year">Copy From Previous Year?</label>
+        <select id="copy-from-year" class="border rounded px-2 py-1 w-full">
+          <option value="">No</option>
+        </select>
+      </div>
+      <div class="flex justify-end gap-4">
+        <button type="button" id="cancel-new-app" class="px-4 py-2 rounded border">Cancel</button>
+        <button type="submit" class="bg-legend-blue hover:bg-legend-gold text-white font-bold py-2 px-4 rounded-xl shadow transition">Create</button>
+      </div>
+    </form>
   
     <!-- Center this whole block as a flex-col group -->
     <div class="flex flex-col items-center w-full">


### PR DESCRIPTION
## Summary
- allow selecting application year and type
- enable creating new applications with optional copy from prior year
- add comprehensive tests for application creation flows

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688fa2ed865c832d9bc371d34ed2af2e