### PR TITLE
fix: avoid FIELD_TYPES redeclaration

### DIFF
--- a/public/js/application-config.js
+++ b/public/js/application-config.js
@@ -1,5 +1,7 @@
 // application-config.js
 
+// Wrap in IIFE to avoid polluting global scope and redeclaration errors
+(function () {
 // Import shared modules (CommonJS for tests, globals for browser)
 let FIELD_TYPES, renderFieldTypeOptions, getProgramId, createOrCopyApplication, showError, clearError, showSuccess, renderApplicationBuilder;
 if (typeof module !== 'undefined' && module.exports) {
@@ -249,9 +251,9 @@ let currentType = 'delegate';
       }
     });
 
-    });
+      });
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = { getProgramId, renderFieldTypeOptions, createOrCopyApplication };
 }
-    
+})();


### PR DESCRIPTION
## Summary
- wrap application-config script in an IIFE to avoid re-declaring global identifiers like FIELD_TYPES

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688fef8e3d30832da1bc49ac95e4d0cb