### PR TITLE
test: expand coverage for application modules

### DIFF
--- a/test/application-config.test.js
+++ b/test/application-config.test.js
@@ -137,6 +137,19 @@ describe('application-config.js', () => {
     expect(elements['publicApplicationUrl'].value).toContain('apply.html?programId=p1');
     expect(elements['publicApplicationUrl'].value).toContain('year=2024');
     expect(elements['publicApplicationUrl'].value).toContain('type=delegate');
+
+    await new Promise(r => setTimeout(r, 0));
+
+    const yearInputHandler = elements['new-app-year'].addEventListener.mock.calls.find(([ev]) => ev === 'input')[1];
+    elements['new-app-year'].value = '2025';
+    yearInputHandler();
+    expect(elements['copy-from-year'].innerHTML).not.toBe('');
+    expect(elements['create-app-submit'].disabled).toBe(false);
+
+    elements['new-app-year'].value = '';
+    yearInputHandler();
+    expect(elements['year-error'].textContent).toBe('Year required');
+    expect(elements['create-app-submit'].disabled).toBe(true);
   });
 
   test('createOrCopyApplication creates year and copies from previous', async () => {

--- a/test/application-field-types.test.js
+++ b/test/application-field-types.test.js
@@ -1,0 +1,16 @@
+const { FIELD_TYPES, renderFieldTypeOptions } = require('../public/js/application-field-types.js');
+
+describe('application-field-types.js', () => {
+  test('FIELD_TYPES includes expected entries', () => {
+    const values = FIELD_TYPES.map(t => t.value);
+    expect(values).toContain('short_answer');
+    expect(values).toContain('address');
+  });
+
+  test('renderFieldTypeOptions renders all options and selects value', () => {
+    const html = renderFieldTypeOptions('phone');
+    const optionCount = (html.match(/<option/g) || []).length;
+    expect(optionCount).toBe(FIELD_TYPES.length);
+    expect(html).toContain('<option value="phone" selected>Phone Number</option>');
+  });
+});

--- a/test/application-messages.test.js
+++ b/test/application-messages.test.js
@@ -1,0 +1,39 @@
+const { showError, clearError, showSuccess } = require('../public/js/application-messages.js');
+
+describe('application-messages.js', () => {
+  let errorBox, successBox;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    errorBox = { textContent: '', style: { display: 'none' } };
+    successBox = { textContent: '', style: { display: 'none' } };
+    global.document = {
+      getElementById: id => (id === 'errorBox' ? errorBox : id === 'successBox' ? successBox : null)
+    };
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('showError displays message', () => {
+    showError('oops');
+    expect(errorBox.textContent).toBe('oops');
+    expect(errorBox.style.display).toBe('block');
+  });
+
+  test('clearError hides message', () => {
+    errorBox.textContent = 'err';
+    errorBox.style.display = 'block';
+    clearError();
+    expect(errorBox.textContent).toBe('');
+    expect(errorBox.style.display).toBe('none');
+  });
+
+  test('showSuccess displays then hides message', () => {
+    showSuccess('yay');
+    expect(successBox.textContent).toBe('yay');
+    expect(successBox.style.display).toBe('block');
+    jest.runAllTimers();
+    expect(successBox.style.display).toBe('none');
+    expect(successBox.textContent).toBe('');
+  });
+});

--- a/test/apply-validation.test.js
+++ b/test/apply-validation.test.js
@@ -1,4 +1,4 @@
-const { validateField, addValidationListeners, formatPhoneNumber } = require('../public/js/apply-validation.js');
+const { validateField, addValidationListeners, formatPhoneNumber, isValidPhoneNumber } = require('../public/js/apply-validation.js');
 
 describe('validateField', () => {
   beforeEach(() => {
@@ -276,5 +276,20 @@ describe('addValidationListeners', () => {
     addValidationListeners(form, config);
     // No listeners should be attached and no errors thrown
     expect(form.querySelectorAll).not.toHaveBeenCalled();
+  });
+});
+
+describe('phone utilities', () => {
+  test('formatPhoneNumber formats various lengths', () => {
+    expect(formatPhoneNumber('')).toBe('');
+    expect(formatPhoneNumber('1')).toBe('(1');
+    expect(formatPhoneNumber('1234')).toBe('(123) 4');
+    expect(formatPhoneNumber('1234567890')).toBe('(123) 456-7890');
+  });
+
+  test('isValidPhoneNumber validates correctly', () => {
+    expect(isValidPhoneNumber('(123) 456-7890')).toBe(true);
+    expect(isValidPhoneNumber('1234567')).toBe(false);
+    expect(isValidPhoneNumber('')).toBe(false);
   });
 });

--- a/test/branding-contact.test.js
+++ b/test/branding-contact.test.js
@@ -88,8 +88,20 @@ describe('branding-contact.js', () => {
     expect(elements.welcomeMessage.value).toBe('');
   });
 
+  test('loadBrandingContactFromApi handles fetch error', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('fail')));
+    await funcs.loadBrandingContactFromApi();
+    expect(elements.errorMsg.style.display).toBe('block');
+  });
+
   test('saveConfig handles failure', async () => {
     global.fetch = jest.fn(() => Promise.resolve({ ok: false }));
+    await funcs.saveConfig();
+    expect(elements.errorMsg.style.display).toBe('block');
+  });
+
+  test('saveConfig handles fetch error', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('boom')));
     await funcs.saveConfig();
     expect(elements.errorMsg.style.display).toBe('block');
   });


### PR DESCRIPTION
## Summary
- extend application configuration tests to cover new application form validation
- add unit tests for application field type options and message helpers
- broaden branding-contact and apply-validation tests with additional edge cases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688ff0202098832d9ef97f361458a58c