### PR TITLE
fix: avoid duplicate global declarations

### DIFF
--- a/public/application-config.html
+++ b/public/application-config.html
@@ -123,6 +123,7 @@
   <script src="js/application-field-types.js"></script>
   <script src="js/application-messages.js"></script>
   <script src="js/application-service.js"></script>
+  <script src="js/application-builder.js"></script>
   <script src="js/application-config.js"></script>
 </body>
 </html>

--- a/public/js/application-builder.js
+++ b/public/js/application-builder.js
@@ -1,5 +1,7 @@
 // application-builder.js
 
+// Wrap in IIFE to avoid redeclaration of globals
+(function () {
 // Import dependencies (CommonJS for tests, globals for browser)
 let renderFieldTypeOptions, showError, clearError, showSuccess;
 if (typeof module !== 'undefined' && module.exports) {
@@ -250,4 +252,5 @@ if (typeof module !== 'undefined' && module.exports) {
 } else {
   window.renderApplicationBuilder = renderApplicationBuilder;
 }
+})();
 

--- a/public/js/application-field-types.js
+++ b/public/js/application-field-types.js
@@ -1,33 +1,36 @@
 // application-field-types.js
 
-// Supported field types with labels and config
-const FIELD_TYPES = [
-  { value: "short_answer", label: "Short Answer" },
-  { value: "paragraph", label: "Paragraph" },
-  { value: "dropdown", label: "Dropdown (Select)" },
-  { value: "radio", label: "Radio Buttons" },
-  { value: "checkbox", label: "Checkboxes" },
-  { value: "date", label: "Date Picker" },
-  { value: "date_range", label: "Date Range" },
-  { value: "phone", label: "Phone Number" },
-  { value: "number", label: "Number" },
-  { value: "email", label: "Email" },
-  { value: "file", label: "Document Upload" },
-  { value: "section", label: "Section/Header" },
-  { value: "static_text", label: "Static Text / Instructions" },
-  { value: "boolean", label: "Yes/No (Boolean)" },
-  { value: "address", label: "Address" }
-];
+// Wrap in IIFE to avoid polluting the global scope and redeclaration errors
+(function () {
+  // Supported field types with labels and config
+  const FIELD_TYPES = [
+    { value: "short_answer", label: "Short Answer" },
+    { value: "paragraph", label: "Paragraph" },
+    { value: "dropdown", label: "Dropdown (Select)" },
+    { value: "radio", label: "Radio Buttons" },
+    { value: "checkbox", label: "Checkboxes" },
+    { value: "date", label: "Date Picker" },
+    { value: "date_range", label: "Date Range" },
+    { value: "phone", label: "Phone Number" },
+    { value: "number", label: "Number" },
+    { value: "email", label: "Email" },
+    { value: "file", label: "Document Upload" },
+    { value: "section", label: "Section/Header" },
+    { value: "static_text", label: "Static Text / Instructions" },
+    { value: "boolean", label: "Yes/No (Boolean)" },
+    { value: "address", label: "Address" }
+  ];
 
-function renderFieldTypeOptions(selected) {
-  return FIELD_TYPES.map(
-    t => `<option value="${t.value}"${selected === t.value ? " selected" : ""}>${t.label}</option>`
-  ).join("");
-}
+  function renderFieldTypeOptions(selected) {
+    return FIELD_TYPES.map(
+      t => `<option value="${t.value}"${selected === t.value ? " selected" : ""}>${t.label}</option>`
+    ).join("");
+  }
 
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { FIELD_TYPES, renderFieldTypeOptions };
-} else {
-  window.FIELD_TYPES = FIELD_TYPES;
-  window.renderFieldTypeOptions = renderFieldTypeOptions;
-}
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { FIELD_TYPES, renderFieldTypeOptions };
+  } else {
+    window.FIELD_TYPES = FIELD_TYPES;
+    window.renderFieldTypeOptions = renderFieldTypeOptions;
+  }
+})();

--- a/public/js/application-messages.js
+++ b/public/js/application-messages.js
@@ -1,37 +1,40 @@
 // application-messages.js
 
-function showError(msg) {
-  const box = document.getElementById('errorBox');
-  if (box) {
-    box.textContent = msg;
-    box.style.display = 'block';
+// Wrap in IIFE to keep globals clean
+(function () {
+  function showError(msg) {
+    const box = document.getElementById('errorBox');
+    if (box) {
+      box.textContent = msg;
+      box.style.display = 'block';
+    }
   }
-}
 
-function clearError() {
-  const box = document.getElementById('errorBox');
-  if (box) {
-    box.textContent = '';
-    box.style.display = 'none';
-  }
-}
-
-function showSuccess(msg) {
-  const box = document.getElementById('successBox');
-  if (box) {
-    box.textContent = msg;
-    box.style.display = 'block';
-    setTimeout(() => {
-      box.style.display = 'none';
+  function clearError() {
+    const box = document.getElementById('errorBox');
+    if (box) {
       box.textContent = '';
-    }, 2000);
+      box.style.display = 'none';
+    }
   }
-}
 
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { showError, clearError, showSuccess };
-} else {
-  window.showError = showError;
-  window.clearError = clearError;
-  window.showSuccess = showSuccess;
-}
+  function showSuccess(msg) {
+    const box = document.getElementById('successBox');
+    if (box) {
+      box.textContent = msg;
+      box.style.display = 'block';
+      setTimeout(() => {
+        box.style.display = 'none';
+        box.textContent = '';
+      }, 2000);
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { showError, clearError, showSuccess };
+  } else {
+    window.showError = showError;
+    window.clearError = clearError;
+    window.showSuccess = showSuccess;
+  }
+})();


### PR DESCRIPTION
## Summary
- wrap application-field-types, application-messages, and application-builder scripts in IIFEs to prevent global redeclaration errors
- include application-builder.js in application-config.html to ensure builder functions available

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689014400b60832da48cb0ec4eb9a218